### PR TITLE
Bug fixes with duplication lifecycle on Windows (requires WSL)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-cli"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-daemon"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-gateway"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-mcp"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-protocol"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 authors = ["tamux contributors"]

--- a/crates/amux-cli/src/client.rs
+++ b/crates/amux-cli/src/client.rs
@@ -221,18 +221,20 @@ pub async fn clone_session(
     workspace_id: Option<String>,
     cols: Option<u16>,
     rows: Option<u16>,
-) -> Result<String> {
+    cwd: Option<String>,
+) -> Result<(String, Option<String>)> {
     let source_uuid = source_id.parse().context("invalid source session ID")?;
     match roundtrip(ClientMessage::CloneSession {
         source_id: source_uuid,
         workspace_id,
         cols,
         rows,
-        replay_scrollback: true,
+        replay_scrollback: false,
+        cwd,
     })
     .await?
     {
-        DaemonMessage::SessionCloned { id, .. } => Ok(id.to_string()),
+        DaemonMessage::SessionCloned { id, active_command, .. } => Ok((id.to_string(), active_command)),
         DaemonMessage::Error { message } => anyhow::bail!("daemon error: {message}"),
         other => anyhow::bail!("unexpected response: {other:?}"),
     }
@@ -347,6 +349,17 @@ pub async fn run_bridge(
         .send(ClientMessage::GetScrollback {
             id: session_id,
             max_lines: None,
+        })
+        .await
+        .ok();
+
+    // Nudge the PTY with a resize so that shells (especially wsl.exe on Windows)
+    // redraw their prompt even if the initial output was produced before we subscribed.
+    framed
+        .send(ClientMessage::Resize {
+            id: session_id,
+            cols,
+            rows,
         })
         .await
         .ok();

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -51,6 +51,9 @@ enum Commands {
         /// Optional workspace override.
         #[arg(short, long)]
         workspace: Option<String>,
+        /// Fallback CWD when the source session's CWD cannot be resolved.
+        #[arg(long)]
+        cwd: Option<String>,
     },
 
     /// Kill a session.
@@ -194,9 +197,13 @@ async fn main() -> Result<()> {
             cols,
             rows,
             workspace,
+            cwd,
         } => {
-            let id = client::clone_session(&source, workspace, cols, rows).await?;
+            let (id, active_command) = client::clone_session(&source, workspace, cols, rows, cwd).await?;
             println!("{id}");
+            if let Some(cmd) = active_command {
+                println!("active_command:{cmd}");
+            }
         }
 
         Commands::Kill { id } => {

--- a/crates/amux-daemon/src/pty_session.rs
+++ b/crates/amux-daemon/src/pty_session.rs
@@ -37,6 +37,8 @@ pub struct PtySession {
     scrollback: Arc<std::sync::Mutex<Vec<u8>>>,
     dead: Arc<AtomicBool>,
     managed_lane: Arc<std::sync::Mutex<ManagedLaneState>>,
+    /// Last active (still-running) command detected via shell integration markers.
+    active_command: Arc<std::sync::Mutex<Option<String>>>,
 }
 
 struct ManagedQueuedCommand {
@@ -116,6 +118,8 @@ impl PtySession {
 
         let dead = Arc::new(AtomicBool::new(false));
         let managed_lane = Arc::new(std::sync::Mutex::new(ManagedLaneState::default()));
+        let active_command: Arc<std::sync::Mutex<Option<String>>> =
+            Arc::new(std::sync::Mutex::new(None));
 
         let created_at = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -129,6 +133,7 @@ impl PtySession {
             let dead = dead.clone();
             let master_write = master_write.clone();
             let managed_lane = managed_lane.clone();
+            let active_command = active_command.clone();
             let workspace_id = workspace_id.clone();
             let cwd = cwd.clone();
             std::thread::Builder::new()
@@ -142,6 +147,7 @@ impl PtySession {
                         scrollback,
                         dead,
                         managed_lane,
+                        active_command,
                         history,
                         workspace_id,
                         cwd,
@@ -164,6 +170,7 @@ impl PtySession {
             scrollback,
             dead,
             managed_lane,
+            active_command,
         })
     }
 
@@ -334,6 +341,13 @@ impl PtySession {
     pub fn is_dead(&self) -> bool {
         self.dead.load(Ordering::SeqCst)
     }
+
+    /// Return the last active (still-running) command detected via shell
+    /// integration markers, or `None` if the shell has no integration or
+    /// the last command has finished.
+    pub fn active_command(&self) -> Option<String> {
+        self.active_command.lock().unwrap().clone()
+    }
 }
 
 /// Background thread that continuously reads PTY output and fans it out.
@@ -345,6 +359,7 @@ fn pty_reader_loop(
     scrollback: Arc<std::sync::Mutex<Vec<u8>>>,
     dead: Arc<AtomicBool>,
     managed_lane: Arc<std::sync::Mutex<ManagedLaneState>>,
+    active_command: Arc<std::sync::Mutex<Option<String>>>,
     history: HistoryStore,
     workspace_id: Option<String>,
     cwd: Option<String>,
@@ -359,6 +374,7 @@ fn pty_reader_loop(
                 break;
             }
             Ok(n) => {
+                tracing::trace!(%id, bytes = n, "PTY reader got output");
                 let mut chunk = Vec::with_capacity(marker_tail.len() + n);
                 if !marker_tail.is_empty() {
                     chunk.extend_from_slice(&marker_tail);
@@ -390,6 +406,7 @@ fn pty_reader_loop(
                 for marker in markers {
                     match marker {
                         CommandLifecycleMarker::Started(command) => {
+                            *active_command.lock().unwrap() = Some(command.clone());
                             let _ = tx.send(DaemonMessage::CommandStarted {
                                 id,
                                 command: command.clone(),
@@ -405,6 +422,7 @@ fn pty_reader_loop(
                             }
                         }
                         CommandLifecycleMarker::Finished(exit_code) => {
+                            *active_command.lock().unwrap() = None;
                             let _ = tx.send(DaemonMessage::CommandFinished { id, exit_code });
 
                             let completed = {
@@ -596,6 +614,57 @@ fn extract_command_markers(data: &[u8]) -> (Vec<CommandLifecycleMarker>, Vec<u8>
     }
 
     (markers, cleaned, trailing)
+}
+
+/// Strip CSI sequences that are terminal-to-host responses (focus events,
+/// device attribute responses, cursor position reports) which are meaningless
+/// and disruptive when replayed into a new terminal session.
+pub fn sanitize_scrollback_for_replay(data: &[u8]) -> Vec<u8> {
+    let mut cleaned = Vec::with_capacity(data.len());
+    let mut i = 0;
+
+    while i < data.len() {
+        // Detect CSI: ESC [
+        if i + 1 < data.len() && data[i] == 0x1b && data[i + 1] == b'[' {
+            let mut j = i + 2;
+            // Skip parameter bytes (0x30..=0x3F): digits ; ? > =
+            while j < data.len() && (0x30..=0x3F).contains(&data[j]) {
+                j += 1;
+            }
+            // Skip intermediate bytes (0x20..=0x2F)
+            while j < data.len() && (0x20..=0x2F).contains(&data[j]) {
+                j += 1;
+            }
+            // Final byte (0x40..=0x7E)
+            if j < data.len() && (0x40..=0x7E).contains(&data[j]) {
+                let final_byte = data[j];
+                let params_start = i + 2;
+                let should_strip = match final_byte {
+                    b'I' | b'O' => true, // Focus In / Focus Out
+                    b'c' => {
+                        // DA1 (\x1b[?..c), DA2 (\x1b[>..c), DA3 (\x1b[=..c), plain DA
+                        let first = data.get(params_start).copied();
+                        matches!(first, Some(b'?') | Some(b'>') | Some(b'='))
+                            || params_start == j
+                    }
+                    b'R' => {
+                        // Cursor Position Report: \x1b[<digits>;<digits>R
+                        data[params_start..j]
+                            .iter()
+                            .all(|&b| b.is_ascii_digit() || b == b';')
+                    }
+                    _ => false,
+                };
+                if should_strip {
+                    i = j + 1;
+                    continue;
+                }
+            }
+        }
+        cleaned.push(data[i]);
+        i += 1;
+    }
+    cleaned
 }
 
 fn notify_session_exited(

--- a/crates/amux-daemon/src/pty_session.rs
+++ b/crates/amux-daemon/src/pty_session.rs
@@ -39,6 +39,8 @@ pub struct PtySession {
     managed_lane: Arc<std::sync::Mutex<ManagedLaneState>>,
     /// Last active (still-running) command detected via shell integration markers.
     active_command: Arc<std::sync::Mutex<Option<String>>>,
+    /// CWD reported by the shell integration (works on all platforms).
+    tracked_cwd: Arc<std::sync::Mutex<Option<String>>>,
 }
 
 struct ManagedQueuedCommand {
@@ -63,6 +65,7 @@ struct ManagedLaneState {
 enum CommandLifecycleMarker {
     Started(String),
     Finished(Option<i32>),
+    Cwd(String),
 }
 
 impl PtySession {
@@ -90,8 +93,24 @@ impl PtySession {
         let shell_program = configured_shell.clone().unwrap_or_else(default_shell);
         tracing::info!(id = %id, shell = %shell_program, "starting PTY shell");
         let mut cmd = CommandBuilder::new(&shell_program);
-        configure_shell_command(&shell_program, &mut cmd)?;
+        configure_shell_command(&shell_program, &mut cmd, cwd.as_deref())?;
 
+        // On Windows with WSL, the CWD is passed via --cd flag (handled by
+        // configure_shell_command). For all other shells, set the process CWD.
+        #[cfg(windows)]
+        {
+            let is_wsl = std::path::Path::new(&shell_program)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.to_ascii_lowercase())
+                .map_or(false, |n| n == "wsl" || n == "wsl.exe");
+            if !is_wsl {
+                if let Some(ref dir) = cwd {
+                    cmd.cwd(dir);
+                }
+            }
+        }
+        #[cfg(not(windows))]
         if let Some(ref dir) = cwd {
             cmd.cwd(dir);
         }
@@ -120,6 +139,8 @@ impl PtySession {
         let managed_lane = Arc::new(std::sync::Mutex::new(ManagedLaneState::default()));
         let active_command: Arc<std::sync::Mutex<Option<String>>> =
             Arc::new(std::sync::Mutex::new(None));
+        let tracked_cwd: Arc<std::sync::Mutex<Option<String>>> =
+            Arc::new(std::sync::Mutex::new(None));
 
         let created_at = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -134,6 +155,7 @@ impl PtySession {
             let master_write = master_write.clone();
             let managed_lane = managed_lane.clone();
             let active_command = active_command.clone();
+            let tracked_cwd = tracked_cwd.clone();
             let workspace_id = workspace_id.clone();
             let cwd = cwd.clone();
             std::thread::Builder::new()
@@ -148,6 +170,7 @@ impl PtySession {
                         dead,
                         managed_lane,
                         active_command,
+                        tracked_cwd,
                         history,
                         workspace_id,
                         cwd,
@@ -171,6 +194,7 @@ impl PtySession {
             dead,
             managed_lane,
             active_command,
+            tracked_cwd,
         })
     }
 
@@ -303,8 +327,13 @@ impl PtySession {
     }
 
     /// Resolve the most current working directory for this PTY process.
-    /// Falls back to the startup cwd when process cwd cannot be queried.
+    /// Priority: shell-integration tracked CWD → /proc/{pid}/cwd (Unix) → startup CWD.
     pub fn resolved_cwd(&self) -> Option<String> {
+        // Shell integration CWD (works on all platforms when integration is active).
+        if let Some(cwd) = self.tracked_cwd.lock().unwrap().clone() {
+            return Some(cwd);
+        }
+
         #[cfg(unix)]
         {
             if let Some(pid) = self.child.lock().unwrap().process_id() {
@@ -360,6 +389,7 @@ fn pty_reader_loop(
     dead: Arc<AtomicBool>,
     managed_lane: Arc<std::sync::Mutex<ManagedLaneState>>,
     active_command: Arc<std::sync::Mutex<Option<String>>>,
+    tracked_cwd: Arc<std::sync::Mutex<Option<String>>>,
     history: HistoryStore,
     workspace_id: Option<String>,
     cwd: Option<String>,
@@ -491,6 +521,9 @@ fn pty_reader_loop(
                                 }
                             }
                         }
+                        CommandLifecycleMarker::Cwd(dir) => {
+                            *tracked_cwd.lock().unwrap() = Some(dir);
+                        }
                     }
                 }
             }
@@ -602,6 +635,17 @@ fn extract_command_markers(data: &[u8]) -> (Vec<CommandLifecycleMarker>, Vec<u8>
                         i = end + terminator_len;
                         continue;
                     }
+
+                    if let Some(cwd_b64) = text.strip_prefix("133;P;") {
+                        let dir = base64::engine::general_purpose::STANDARD
+                            .decode(cwd_b64)
+                            .ok()
+                            .and_then(|bytes| String::from_utf8(bytes).ok())
+                            .unwrap_or_else(|| cwd_b64.to_string());
+                        markers.push(CommandLifecycleMarker::Cwd(dir));
+                        i = end + terminator_len;
+                        continue;
+                    }
                 }
             } else {
                 trailing.extend_from_slice(&data[i..]);
@@ -693,38 +737,9 @@ fn default_shell() -> String {
     }
 }
 
-#[cfg(windows)]
-fn configure_shell_command(shell_program: &str, cmd: &mut CommandBuilder) -> Result<()> {
-    let shell_name = std::path::Path::new(shell_program)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .map(|name| name.to_ascii_lowercase());
-
-    match shell_name.as_deref() {
-        Some("powershell.exe") | Some("pwsh.exe") => {
-            cmd.arg("-NoLogo");
-            cmd.arg("-NoExit");
-        }
-        _ => {}
-    }
-
-    Ok(())
-}
-
-#[cfg(not(windows))]
-fn configure_shell_command(shell_program: &str, cmd: &mut CommandBuilder) -> Result<()> {
-    let shell_name = std::path::Path::new(shell_program)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .map(|name| name.to_ascii_lowercase());
-
-    if matches!(shell_name.as_deref(), Some("bash")) {
-        let data_dir = amux_protocol::ensure_amux_data_dir()?;
-        let integration_dir = data_dir.join("shell");
-        std::fs::create_dir_all(&integration_dir)?;
-
-        let bash_rc_path = integration_dir.join("bash_amux_rc.sh");
-        let bash_rc = r#"# amux shell integration for command lifecycle markers
+/// Shell integration script that injects command lifecycle markers (OSC 133)
+/// into bash. Used on both native Unix and inside WSL on Windows.
+const BASH_AMUX_RC: &str = r#"# amux shell integration for command lifecycle markers
 if [ -f /etc/bash.bashrc ]; then
     . /etc/bash.bashrc
 fi
@@ -736,6 +751,9 @@ fi
 __amux_precmd() {
     local exit_code=$?
     printf '\033]133;D;%s\a' "$exit_code"
+    local cwd_b64
+    cwd_b64="$(printf '%s' "$PWD" | base64 | tr -d '\r\n')"
+    printf '\033]133;P;%s\a' "$cwd_b64"
 }
 
 __amux_preexec() {
@@ -761,8 +779,85 @@ else
     PROMPT_COMMAND="__amux_precmd"
 fi
 "#;
-        std::fs::write(&bash_rc_path, bash_rc)?;
 
+/// Write the bash integration RC file and return its path.
+fn ensure_bash_rc() -> Result<std::path::PathBuf> {
+    let data_dir = amux_protocol::ensure_amux_data_dir()?;
+    let integration_dir = data_dir.join("shell");
+    std::fs::create_dir_all(&integration_dir)?;
+    let bash_rc_path = integration_dir.join("bash_amux_rc.sh");
+    std::fs::write(&bash_rc_path, BASH_AMUX_RC)?;
+    Ok(bash_rc_path)
+}
+
+/// Convert a Windows path (e.g. `C:\Users\foo\bar`) to a WSL-accessible
+/// path (`/mnt/c/Users/foo/bar`).
+#[cfg(windows)]
+fn windows_path_to_wsl(path: &std::path::Path) -> String {
+    let s = path.to_string_lossy();
+    let bytes = s.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+    {
+        let drive = (bytes[0] as char).to_ascii_lowercase();
+        let rest = &s[3..];
+        format!("/mnt/{}/{}", drive, rest.replace('\\', "/"))
+    } else {
+        s.replace('\\', "/")
+    }
+}
+
+#[cfg(windows)]
+fn configure_shell_command(shell_program: &str, cmd: &mut CommandBuilder, cwd: Option<&str>) -> Result<()> {
+    let shell_name = std::path::Path::new(shell_program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_ascii_lowercase());
+
+    match shell_name.as_deref() {
+        Some("powershell.exe") | Some("pwsh.exe") => {
+            cmd.arg("-NoLogo");
+            cmd.arg("-NoExit");
+        }
+        Some("wsl") | Some("wsl.exe") => {
+            // Set CWD inside WSL via --cd (must come before --)
+            if let Some(dir) = cwd {
+                cmd.arg("--cd");
+                cmd.arg(dir);
+            }
+
+            // Launch bash inside WSL with amux shell integration so that
+            // command lifecycle markers work across the WSL boundary.
+            match ensure_bash_rc() {
+                Ok(rc_path) => {
+                    let wsl_rc_path = windows_path_to_wsl(&rc_path);
+                    cmd.arg("--");
+                    cmd.arg("bash");
+                    cmd.arg("--rcfile");
+                    cmd.arg(wsl_rc_path);
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to write bash RC for WSL; launching without integration");
+                }
+            }
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn configure_shell_command(shell_program: &str, cmd: &mut CommandBuilder, _cwd: Option<&str>) -> Result<()> {
+    let shell_name = std::path::Path::new(shell_program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_ascii_lowercase());
+
+    if matches!(shell_name.as_deref(), Some("bash")) {
+        let bash_rc_path = ensure_bash_rc()?;
         cmd.arg("--rcfile");
         cmd.arg(bash_rc_path.to_string_lossy().to_string());
     }

--- a/crates/amux-daemon/src/server.rs
+++ b/crates/amux-daemon/src/server.rs
@@ -182,11 +182,35 @@ where
             // Select between client input and all attached session outputs.
             // For simplicity we drain all pending broadcast messages first.
             let mut forwarded = false;
-            for (_sid, rx) in attached_rxs.iter_mut() {
-                while let Ok(daemon_msg) = rx.try_recv() {
-                    framed.send(daemon_msg).await?;
-                    forwarded = true;
+            let mut closed_sessions = Vec::new();
+            for (sid, rx) in attached_rxs.iter_mut() {
+                loop {
+                    match rx.try_recv() {
+                        Ok(daemon_msg) => {
+                            framed.send(daemon_msg).await?;
+                            forwarded = true;
+                        }
+                        Err(broadcast::error::TryRecvError::Empty) => break,
+                        Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                            tracing::warn!(session = %sid, skipped = n, "broadcast lagged");
+                            break;
+                        }
+                        Err(broadcast::error::TryRecvError::Closed) => {
+                            framed
+                                .send(DaemonMessage::SessionExited {
+                                    id: *sid,
+                                    exit_code: None,
+                                })
+                                .await?;
+                            closed_sessions.push(*sid);
+                            forwarded = true;
+                            break;
+                        }
+                    }
                 }
+            }
+            if !closed_sessions.is_empty() {
+                attached_rxs.retain(|(sid, _)| !closed_sessions.contains(sid));
             }
 
             // Now try to read one client message with a short timeout so we
@@ -242,15 +266,16 @@ where
                     cols,
                     rows,
                     replay_scrollback,
+                    cwd,
                 } => {
                     match manager
-                        .clone_session(source_id, workspace_id, cols, rows, replay_scrollback)
+                        .clone_session(source_id, workspace_id, cols, rows, replay_scrollback, cwd)
                         .await
                     {
-                        Ok((id, rx)) => {
+                        Ok((id, rx, active_command)) => {
                             attached_rxs.push((id, rx));
                             framed
-                                .send(DaemonMessage::SessionCloned { source_id, id })
+                                .send(DaemonMessage::SessionCloned { source_id, id, active_command })
                                 .await?;
                         }
                         Err(e) => {
@@ -264,9 +289,17 @@ where
                 }
 
                 ClientMessage::AttachSession { id } => match manager.subscribe(id).await {
-                    Ok(rx) => {
+                    Ok((rx, alive)) => {
                         attached_rxs.push((id, rx));
                         framed.send(DaemonMessage::SessionAttached { id }).await?;
+                        if !alive {
+                            framed
+                                .send(DaemonMessage::SessionExited {
+                                    id,
+                                    exit_code: None,
+                                })
+                                .await?;
+                        }
                     }
                     Err(e) => {
                         framed

--- a/crates/amux-daemon/src/session_manager.rs
+++ b/crates/amux-daemon/src/session_manager.rs
@@ -86,7 +86,8 @@ impl SessionManager {
         cols: Option<u16>,
         rows: Option<u16>,
         replay_scrollback: bool,
-    ) -> Result<(SessionId, broadcast::Receiver<DaemonMessage>)> {
+        cwd_override: Option<String>,
+    ) -> Result<(SessionId, broadcast::Receiver<DaemonMessage>, Option<String>)> {
         let source = self
             .sessions
             .read()
@@ -95,11 +96,11 @@ impl SessionManager {
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("session not found: {source_id}"))?;
 
-        let (shell, cwd, source_workspace_id, source_cols, source_rows, replay_bytes) = {
+        let (shell, cwd, source_workspace_id, source_cols, source_rows, replay_bytes, src_active_cmd) = {
             let source = source.lock().await;
             (
                 source.shell().map(ToOwned::to_owned),
-                source.resolved_cwd(),
+                source.resolved_cwd().or(cwd_override),
                 source.workspace_id().map(ToOwned::to_owned),
                 source.cols(),
                 source.rows(),
@@ -108,6 +109,7 @@ impl SessionManager {
                 } else {
                     Vec::new()
                 },
+                source.active_command(),
             )
         };
 
@@ -124,13 +126,15 @@ impl SessionManager {
             .await?;
 
         if replay_scrollback && !replay_bytes.is_empty() {
+            let sanitized =
+                crate::pty_session::sanitize_scrollback_for_replay(&replay_bytes);
             if let Some(cloned_session) = self.sessions.read().await.get(&id).cloned() {
-                cloned_session.lock().await.preload_output(&replay_bytes);
+                cloned_session.lock().await.preload_output(&sanitized);
             }
         }
 
-        tracing::info!(%source_id, %id, "session cloned");
-        Ok((id, rx))
+        tracing::info!(%source_id, %id, active_command = ?src_active_cmd, "session cloned");
+        Ok((id, rx, src_active_cmd))
     }
 
     /// Send raw input bytes to a session's PTY stdin.
@@ -176,14 +180,21 @@ impl SessionManager {
     }
 
     /// Subscribe to a session's output broadcast channel.
-    pub async fn subscribe(&self, id: SessionId) -> Result<broadcast::Receiver<DaemonMessage>> {
+    /// Returns `(receiver, alive)` where `alive` is `false` when the session's
+    /// PTY has already exited (so the caller can immediately notify the client).
+    pub async fn subscribe(
+        &self,
+        id: SessionId,
+    ) -> Result<(broadcast::Receiver<DaemonMessage>, bool)> {
         let sessions = self.sessions.read().await;
         let session = sessions
             .get(&id)
             .ok_or_else(|| anyhow::anyhow!("session not found: {id}"))?
             .clone();
-        let rx = session.lock().await.subscribe();
-        Ok(rx)
+        let s = session.lock().await;
+        let rx = s.subscribe();
+        let alive = !s.is_dead();
+        Ok((rx, alive))
     }
 
     /// List all running sessions.

--- a/crates/amux-protocol/src/messages.rs
+++ b/crates/amux-protocol/src/messages.rs
@@ -50,6 +50,9 @@ pub enum ClientMessage {
         rows: Option<u16>,
         /// Whether to preload source scrollback into the clone.
         replay_scrollback: bool,
+        /// Fallback CWD when the source session's CWD cannot be resolved
+        /// (e.g. on Windows where /proc is unavailable).
+        cwd: Option<String>,
     },
 
     /// Detach from a session (stop receiving output; session keeps running).
@@ -149,7 +152,13 @@ pub enum DaemonMessage {
     SessionSpawned { id: SessionId },
 
     /// Confirmation that a session was cloned.
-    SessionCloned { source_id: SessionId, id: SessionId },
+    SessionCloned {
+        source_id: SessionId,
+        id: SessionId,
+        /// The command that was actively running in the source session
+        /// (detected via shell integration), if any.
+        active_command: Option<String>,
+    },
 
     /// Confirmation that the client is now attached.
     SessionAttached { id: SessionId },

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -78,7 +78,7 @@ Minimal example:
 ```json
 {
   "name": "tamux-plugin-example",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "tamuxPlugin": {
     "entry": "dist/tamux-plugin.js",
     "format": "script"
@@ -105,7 +105,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.1.1",
+  version: "0.1.3",
   components: {
     ExamplePanel,
   },

--- a/frontend/electron/main.cjs
+++ b/frontend/electron/main.cjs
@@ -1,5 +1,5 @@
 const { app, BrowserWindow, Menu, clipboard, ipcMain, screen, shell, session } = require('electron');
-const { spawn, spawnSync, execSync } = require('child_process');
+const { spawn, spawnSync, execSync, execFileSync } = require('child_process');
 const { Client, GatewayIntentBits, Partials } = require('discord.js');
 const path = require('path');
 const net = require('net');
@@ -1679,6 +1679,9 @@ async function cloneTerminalSession(_event, payload = {}) {
     if (Number.isFinite(payload.rows)) {
         args.push('--rows', String(Math.max(2, Math.trunc(payload.rows))));
     }
+    if (typeof payload.cwd === 'string' && payload.cwd.trim()) {
+        args.push('--cwd', payload.cwd.trim());
+    }
 
     logToFile('info', 'cloning terminal session', {
         sourcePaneId: sourcePaneId || null,
@@ -1719,19 +1722,24 @@ async function cloneTerminalSession(_event, payload = {}) {
                     .split(/\r?\n/)
                     .map((line) => line.trim())
                     .filter(Boolean);
-                const sessionId = lines[lines.length - 1] ?? '';
+                const sessionId = lines[0] ?? '';
                 if (!sessionId) {
                     reject(new Error('tamux clone did not return a session id'));
                     return;
                 }
 
-                resolve({ sessionId });
+                // Parse optional active_command from daemon
+                const cmdLine = lines.find((l) => l.startsWith('active_command:'));
+                const activeCommand = cmdLine ? cmdLine.slice('active_command:'.length) : null;
+
+                resolve({ sessionId, activeCommand });
             });
         });
 
         logToFile('info', 'cloned terminal session', {
             sourceSessionId,
             clonedSessionId: result.sessionId,
+            activeCommand: result.activeCommand ?? null,
         });
         return result;
     } catch (error) {
@@ -2411,6 +2419,73 @@ function getSystemFonts() {
     }
 }
 
+function getAvailableShells() {
+    const shells = [];
+    try {
+        if (process.platform === 'win32') {
+            // Known Windows shell paths
+            const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+            const windowsShells = [
+                { name: 'Windows PowerShell', path: path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe') },
+                { name: 'Command Prompt', path: path.join(systemRoot, 'System32', 'cmd.exe') },
+            ];
+
+            // PowerShell 7 (try where.exe to find it)
+            try {
+                const pwshPath = execFileSync('where.exe', ['pwsh.exe'], {
+                    encoding: 'utf-8', timeout: 5000, windowsHide: true,
+                }).split('\n')[0].trim();
+                if (pwshPath) {
+                    shells.push({ name: 'PowerShell 7', path: pwshPath });
+                }
+            } catch {}
+
+            for (const s of windowsShells) {
+                if (fs.existsSync(s.path)) {
+                    shells.push(s);
+                }
+            }
+
+            // Detect WSL distributions
+            try {
+                const wslOut = execFileSync('wsl.exe', ['-l', '-q'], {
+                    encoding: 'utf-16le', timeout: 5000, windowsHide: true,
+                });
+                const distros = wslOut.split('\n')
+                    .map((s) => s.replace(/\0/g, '').trim())
+                    .filter(Boolean);
+                if (distros.length > 0) {
+                    shells.push({ name: 'WSL (default)', path: 'wsl' });
+                }
+                for (const distro of distros) {
+                    shells.push({ name: `WSL: ${distro}`, path: 'wsl', args: `-d ${distro}` });
+                }
+            } catch {}
+        } else {
+            // Unix: read /etc/shells
+            try {
+                const content = fs.readFileSync('/etc/shells', 'utf-8');
+                const shellPaths = content.split('\n')
+                    .map((line) => line.trim())
+                    .filter((line) => line && !line.startsWith('#'));
+                for (const shellPath of shellPaths) {
+                    if (fs.existsSync(shellPath)) {
+                        shells.push({ name: path.basename(shellPath), path: shellPath });
+                    }
+                }
+            } catch {}
+
+            // Fallback to $SHELL
+            if (shells.length === 0 && process.env.SHELL) {
+                shells.push({ name: path.basename(process.env.SHELL), path: process.env.SHELL });
+            }
+        }
+    } catch {
+        // Return whatever we collected so far
+    }
+    return shells;
+}
+
 let lastCpuSnapshot = null;
 
 function aggregateCpuTimes() {
@@ -2642,6 +2717,7 @@ function registerIpcHandlers() {
     ipcMain.handle('checkDaemon', () => checkDaemonRunning());
     ipcMain.handle('spawnDaemon', () => spawnDaemon());
     ipcMain.handle('getSystemFonts', () => getSystemFonts());
+    ipcMain.handle('getAvailableShells', () => getAvailableShells());
     ipcMain.handle('system-monitor-snapshot', getSystemMonitorSnapshot);
     ipcMain.handle('getDaemonPath', () => getDaemonPath());
     ipcMain.handle('getPlatform', () => process.platform);

--- a/frontend/electron/preload.cjs
+++ b/frontend/electron/preload.cjs
@@ -103,6 +103,7 @@ const bridgeApi = {
     checkDaemon: () => ipcRenderer.invoke('checkDaemon'),
     spawnDaemon: () => ipcRenderer.invoke('spawnDaemon'),
     getSystemFonts: () => ipcRenderer.invoke('getSystemFonts'),
+    getAvailableShells: () => ipcRenderer.invoke('getAvailableShells'),
     getSystemMonitorSnapshot: (options) => ipcRenderer.invoke('system-monitor-snapshot', options),
     getDaemonPath: () => ipcRenderer.invoke('getDaemonPath'),
     getPlatform: () => ipcRenderer.invoke('getPlatform'),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamux",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamux",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@types/js-yaml": "^4.0.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tamux",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "Agentic terminal multiplexer with AI-native workflows",
   "homepage": "https://tamux.app",
   "author": {

--- a/frontend/src/components/InfiniteCanvasSurface.tsx
+++ b/frontend/src/components/InfiniteCanvasSurface.tsx
@@ -376,14 +376,16 @@ export function InfiniteCanvasSurface({ surface }: InfiniteCanvasSurfaceProps) {
         sourcePanel?.sessionId ?? findLeaf(surface.layout, sourcePaneId)?.sessionId ?? null,
         operationalEvents,
       );
-      const targetSessionId = await cloneSessionForDuplication(sourcePaneId, sourceSessionId, {
+      const sourceWorkspace = useWorkspaceStore.getState().workspaces.find((w) => w.id === surface.workspaceId);
+      const cloneResult = await cloneSessionForDuplication(sourcePaneId, sourceSessionId, {
         workspaceId: surface.workspaceId,
+        cwd: sourceWorkspace?.cwd || null,
       });
       setActivePaneId(sourcePaneId);
       const duplicatedPaneId = createCanvasPanel(surface.id, {
         paneName: `${surface.paneNames[sourcePaneId] ?? sourcePaneId} Copy`,
         paneIcon: surface.paneIcons[sourcePaneId] ?? "terminal",
-        sessionId: targetSessionId ?? null,
+        sessionId: cloneResult?.sessionId ?? null,
         ...(sourcePanel
           ? {
             width: sourcePanel.width,
@@ -395,11 +397,10 @@ export function InfiniteCanvasSurface({ surface }: InfiniteCanvasSurfaceProps) {
       });
       if (!duplicatedPaneId) continue;
 
-      const activeBootstrapCommand = resolveDuplicateActiveBootstrapCommand(sourcePaneId, operationalEvents);
-      const fallbackBootstrapCommand = !targetSessionId
-        ? resolveDuplicateBootstrapCommand(sourcePaneId, operationalEvents)
-        : null;
-      const bootstrapCommand = activeBootstrapCommand ?? fallbackBootstrapCommand;
+      const bootstrapCommand =
+        resolveDuplicateActiveBootstrapCommand(sourcePaneId, operationalEvents)
+        ?? resolveDuplicateBootstrapCommand(sourcePaneId, operationalEvents)
+        ?? cloneResult?.activeCommand;
       if (bootstrapCommand) {
         queuePaneBootstrapCommand(duplicatedPaneId, bootstrapCommand);
       }

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -44,15 +44,20 @@ export function SettingsPanel({ style, className }: SettingsPanelProps = {}) {
 
   const [tab, setTab] = useState<SettingsTab>("appearance");
   const [systemFonts, setSystemFonts] = useState<string[]>([]);
+  const [availableShells, setAvailableShells] = useState<{ name: string; path: string; args?: string }[]>([]);
   const [isFullscreen, setIsFullscreen] = useState(true);
 
   useEffect(() => {
     if (open && systemFonts.length === 0) {
       // Load system fonts via Electron IPC
       if (typeof window !== "undefined" && ("tamux" in window || "amux" in window)) {
-        ((window as any).tamux ?? (window as any).amux).getSystemFonts().then((fonts: string[]) => {
+        const bridge = (window as any).tamux ?? (window as any).amux;
+        bridge.getSystemFonts().then((fonts: string[]) => {
           setSystemFonts(fonts);
         });
+        bridge.getAvailableShells?.().then(
+          (shells: { name: string; path: string; args?: string }[]) => setAvailableShells(shells),
+        ).catch(() => {});
       }
     }
   }, [open]);
@@ -190,6 +195,7 @@ export function SettingsPanel({ style, className }: SettingsPanelProps = {}) {
             <TerminalTab
               settings={settings}
               updateSetting={updateSetting}
+              availableShells={availableShells}
               profiles={profiles}
               addProfile={addProfile}
               removeProfile={removeProfile}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -478,15 +478,17 @@ export function Sidebar() {
         source.sessionId,
         operationalEvents,
       );
-      const targetSessionId = await cloneSessionForDuplication(paneId, sourceSessionId, {
+      const sourceWorkspace = workspaces.find((w) => w.id === source.workspaceId);
+      const cloneResult = await cloneSessionForDuplication(paneId, sourceSessionId, {
         workspaceId: source.workspaceId,
+        cwd: sourceWorkspace?.cwd || null,
       });
 
       if (source.layoutMode === "canvas") {
         const duplicatedPaneId = createCanvasPanel(source.surfaceId, {
           paneName: `${source.paneName} Copy`,
           paneIcon: source.paneIcon,
-          sessionId: targetSessionId ?? null,
+          sessionId: cloneResult?.sessionId ?? null,
           ...(source.panel
             ? {
               width: source.panel.width,
@@ -497,11 +499,10 @@ export function Sidebar() {
             : {}),
         });
         if (!duplicatedPaneId) continue;
-        const activeBootstrapCommand = resolveDuplicateActiveBootstrapCommand(paneId, operationalEvents);
-        const fallbackBootstrapCommand = !targetSessionId
-          ? resolveDuplicateBootstrapCommand(paneId, operationalEvents)
-          : null;
-        const bootstrapCommand = activeBootstrapCommand ?? fallbackBootstrapCommand;
+        const bootstrapCommand =
+          resolveDuplicateActiveBootstrapCommand(paneId, operationalEvents)
+          ?? resolveDuplicateBootstrapCommand(paneId, operationalEvents)
+          ?? cloneResult?.activeCommand;
         if (bootstrapCommand) {
           queuePaneBootstrapCommand(duplicatedPaneId, bootstrapCommand);
         }
@@ -511,15 +512,14 @@ export function Sidebar() {
 
       splitActive("horizontal", `${source.paneName} Copy`, {
         paneIcon: source.paneIcon,
-        sessionId: targetSessionId ?? null,
+        sessionId: cloneResult?.sessionId ?? null,
       });
       const duplicatedPaneId = useWorkspaceStore.getState().activePaneId();
       if (!duplicatedPaneId) continue;
-      const activeBootstrapCommand = resolveDuplicateActiveBootstrapCommand(paneId, operationalEvents);
-      const fallbackBootstrapCommand = !targetSessionId
-        ? resolveDuplicateBootstrapCommand(paneId, operationalEvents)
-        : null;
-      const bootstrapCommand = activeBootstrapCommand ?? fallbackBootstrapCommand;
+      const bootstrapCommand =
+        resolveDuplicateActiveBootstrapCommand(paneId, operationalEvents)
+        ?? resolveDuplicateBootstrapCommand(paneId, operationalEvents)
+        ?? cloneResult?.activeCommand;
       if (bootstrapCommand) {
         queuePaneBootstrapCommand(duplicatedPaneId, bootstrapCommand);
       }

--- a/frontend/src/components/SurfaceTabBar.tsx
+++ b/frontend/src/components/SurfaceTabBar.tsx
@@ -49,24 +49,24 @@ export function SurfaceTabBar() {
       findLeaf(activeSurface.layout, sourcePaneId)?.sessionId ?? null,
       operationalEvents,
     );
-    const targetSessionId = await cloneSessionForDuplication(sourcePaneId, sourceSessionId, {
+    const cloneResult = await cloneSessionForDuplication(sourcePaneId, sourceSessionId, {
       workspaceId: ws.id,
+      cwd: ws.cwd || null,
     });
     const sourcePaneName = activeSurface.paneNames[sourcePaneId] ?? sourcePaneId;
     const sourcePaneIcon = activeSurface.paneIcons[sourcePaneId] ?? "terminal";
 
     splitActive(direction, `${sourcePaneName} Copy`, {
-      sessionId: targetSessionId ?? null,
+      sessionId: cloneResult?.sessionId ?? null,
       paneIcon: sourcePaneIcon,
     });
 
     const duplicatedPaneId = useWorkspaceStore.getState().activePaneId();
     if (!duplicatedPaneId) return;
-    const activeBootstrapCommand = resolveDuplicateActiveBootstrapCommand(sourcePaneId, operationalEvents);
-    const fallbackBootstrapCommand = !targetSessionId
-      ? resolveDuplicateBootstrapCommand(sourcePaneId, operationalEvents)
-      : null;
-    const bootstrapCommand = activeBootstrapCommand ?? fallbackBootstrapCommand;
+    const bootstrapCommand =
+      resolveDuplicateActiveBootstrapCommand(sourcePaneId, operationalEvents)
+      ?? resolveDuplicateBootstrapCommand(sourcePaneId, operationalEvents)
+      ?? cloneResult?.activeCommand;
     if (bootstrapCommand) {
       queuePaneBootstrapCommand(duplicatedPaneId, bootstrapCommand);
     }

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -406,24 +406,24 @@ export function TerminalPane({ paneId, sessionId }: TerminalPaneProps) {
       findLeaf(surface.layout, paneId)?.sessionId ?? requestedSessionIdRef.current ?? null,
       operationalEvents,
     );
-    const targetSessionId = await cloneSessionForDuplication(paneId, sourceSessionId, {
+    const cloneResult = await cloneSessionForDuplication(paneId, sourceSessionId, {
       workspaceId: workspace.id,
+      cwd: workspace.cwd || null,
     });
     const sourceName = surface.paneNames[paneId] ?? paneName;
     const sourceIcon = surface.paneIcons[paneId] ?? "terminal";
 
     splitActive(direction, `${sourceName} Copy`, {
-      sessionId: targetSessionId ?? null,
+      sessionId: cloneResult?.sessionId ?? null,
       paneIcon: sourceIcon,
     });
 
     const duplicatedPaneId = useWorkspaceStore.getState().activePaneId();
     if (!duplicatedPaneId) return;
-    const activeBootstrapCommand = resolveDuplicateActiveBootstrapCommand(paneId, operationalEvents);
-    const fallbackBootstrapCommand = !targetSessionId
-      ? resolveDuplicateBootstrapCommand(paneId, operationalEvents)
-      : null;
-    const bootstrapCommand = activeBootstrapCommand ?? fallbackBootstrapCommand;
+    const bootstrapCommand =
+      resolveDuplicateActiveBootstrapCommand(paneId, operationalEvents)
+      ?? resolveDuplicateBootstrapCommand(paneId, operationalEvents)
+      ?? cloneResult?.activeCommand;
     if (bootstrapCommand) {
       queuePaneBootstrapCommand(duplicatedPaneId, bootstrapCommand);
     }
@@ -1170,7 +1170,7 @@ export function TerminalPane({ paneId, sessionId }: TerminalPaneProps) {
         const cloneSourceSessionId = parseCloneSessionToken(requestedSessionId);
         if (cloneSourceSessionId) {
           const normalizedSourceSessionId = unwrapCloneSessionId(cloneSourceSessionId);
-          const clonedSessionId = await cloneSessionForDuplication(
+          const cloneResult = await cloneSessionForDuplication(
             paneId,
             normalizedSourceSessionId,
             {
@@ -1179,10 +1179,10 @@ export function TerminalPane({ paneId, sessionId }: TerminalPaneProps) {
               rows: term.rows,
             },
           );
-          if (clonedSessionId) {
-            requestedSessionId = clonedSessionId;
-            requestedSessionIdRef.current = clonedSessionId;
-            setPaneSessionId(paneId, clonedSessionId);
+          if (cloneResult?.sessionId) {
+            requestedSessionId = cloneResult.sessionId;
+            requestedSessionIdRef.current = cloneResult.sessionId;
+            setPaneSessionId(paneId, cloneResult.sessionId);
           } else if (normalizedSourceSessionId) {
             // Degrade to source session id to avoid passing invalid clone tokens to the bridge.
             requestedSessionId = normalizedSourceSessionId;

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -48,7 +48,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>tamux - Terminal Multiplexer</p>
-                    <p>Version 0.1.1</p>
+                    <p>Version 0.1.3</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A cross-platform terminal multiplexer with workspaces, surfaces, pane management,
                         AI agent integration, snippet library, and session persistence.

--- a/frontend/src/components/settings-panel/TerminalTab.tsx
+++ b/frontend/src/components/settings-panel/TerminalTab.tsx
@@ -1,9 +1,16 @@
 import type { AmuxSettings, ShellProfile } from "../../lib/types";
 import { addBtnStyle, inputStyle, NumberInput, Section, SettingRow, type SettingsUpdater, SliderInput, smallBtnStyle, TextInput, Toggle } from "./shared";
 
+interface AvailableShell {
+    name: string;
+    path: string;
+    args?: string;
+}
+
 export function TerminalTab({
     settings,
     updateSetting,
+    availableShells,
     profiles,
     addProfile,
     removeProfile,
@@ -12,19 +19,42 @@ export function TerminalTab({
 }: {
     settings: AmuxSettings;
     updateSetting: SettingsUpdater;
+    availableShells: AvailableShell[];
     profiles: ShellProfile[];
     addProfile: (profile: ShellProfile) => void;
     removeProfile: (id: string) => void;
     updateProfile: (id: string, updates: Partial<ShellProfile>) => void;
     setDefaultProfile: (id: string) => void;
 }) {
+    const currentShellInList = availableShells.some((s) => s.path === settings.defaultShell);
+
     return (
         <>
             <Section title="Shell">
                 <SettingRow label="Default Shell">
-                    <TextInput value={settings.defaultShell}
-                        onChange={(value) => updateSetting("defaultShell", value)}
-                        placeholder="(system default)" />
+                    <select
+                        value={settings.defaultShell}
+                        onChange={(e) => {
+                            const selected = availableShells.find((s) => s.path === e.target.value);
+                            updateSetting("defaultShell", e.target.value);
+                            if (selected?.args && !settings.defaultShellArgs) {
+                                updateSetting("defaultShellArgs", selected.args);
+                            }
+                        }}
+                        style={inputStyle}
+                    >
+                        <option value="">(system default)</option>
+                        {availableShells.map((shell) => (
+                            <option key={`${shell.path}:${shell.args ?? ""}`} value={shell.path}>
+                                {shell.name} — {shell.path}
+                            </option>
+                        ))}
+                        {settings.defaultShell && !currentShellInList && (
+                            <option value={settings.defaultShell}>
+                                {settings.defaultShell} (custom)
+                            </option>
+                        )}
+                    </select>
                 </SettingRow>
                 <SettingRow label="Shell Arguments">
                     <TextInput value={settings.defaultShellArgs}

--- a/frontend/src/lib/paneDuplication.ts
+++ b/frontend/src/lib/paneDuplication.ts
@@ -1,19 +1,8 @@
 import type { OperationalEvent } from "./agentMissionStore";
 import { encodeTextToBase64, stripAnsi } from "../components/terminal-pane/utils";
 
-const DUPLICATE_BOOTSTRAP_CMDS = new Set([
-  "codex",
-  "claude",
-  "opencode",
-  "aider",
-]);
-
-function normalizeCommandToken(value: string): string {
-  const trimmed = stripAnsi(value).replace(/[\u0000-\u001f\u007f]/g, " ").trim();
-  if (!trimmed) return "";
-  const firstToken = trimmed.split(/\s+/)[0] ?? "";
-  const baseName = firstToken.split(/[\\/]/).pop() ?? firstToken;
-  return baseName.replace(/\.(exe|cmd|bat|sh)$/i, "").toLowerCase();
+function cleanCommand(value: string): string {
+  return stripAnsi(value).replace(/[\u0000-\u001f\u007f]/g, " ").trim();
 }
 
 export function resolveDuplicateBootstrapCommand(
@@ -25,11 +14,7 @@ export function resolveDuplicateBootstrapCommand(
     .sort((a, b) => b.timestamp - a.timestamp)[0]?.command;
 
   if (!lastCommand) return null;
-  const executable = normalizeCommandToken(lastCommand);
-  if (!DUPLICATE_BOOTSTRAP_CMDS.has(executable)) {
-    return null;
-  }
-  return executable;
+  return cleanCommand(lastCommand) || null;
 }
 
 export function resolveDuplicateActiveBootstrapCommand(
@@ -55,11 +40,7 @@ export function resolveDuplicateActiveBootstrapCommand(
     return null;
   }
 
-  const executable = normalizeCommandToken(activeCommand);
-  if (!DUPLICATE_BOOTSTRAP_CMDS.has(executable)) {
-    return null;
-  }
-  return executable;
+  return cleanCommand(activeCommand) || null;
 }
 
 export function resolveDuplicateSourceSessionId(
@@ -150,10 +131,11 @@ export async function cloneSessionForDuplication(
   sourceSessionId?: string | null,
   opts?: {
     workspaceId?: string | null;
+    cwd?: string | null;
     cols?: number;
     rows?: number;
   },
-): Promise<string | null> {
+): Promise<{ sessionId: string; activeCommand: string | null } | null> {
   const bridge = (window as any).tamux ?? (window as any).amux;
   if (!bridge?.cloneTerminalSession) {
     return null;
@@ -176,13 +158,15 @@ export async function cloneSessionForDuplication(
       sourcePaneId,
       sourceSessionId: normalizedSourceSessionId,
       ...(opts?.workspaceId ? { workspaceId: opts.workspaceId } : {}),
+      ...(opts?.cwd ? { cwd: opts.cwd } : {}),
       ...(typeof cols === "number" ? { cols } : {}),
       ...(typeof rows === "number" ? { rows } : {}),
     });
     const sessionId = typeof result?.sessionId === "string" ? result.sessionId.trim() : "";
-    return sessionId || null;
+    if (!sessionId) return null;
+    const activeCommand = typeof result?.activeCommand === "string" ? result.activeCommand : null;
+    return { sessionId, activeCommand };
   } catch (error) {
-    // Keep duplication flow resilient but visible during debugging.
     console.warn("cloneSessionForDuplication failed", {
       sourcePaneId,
       sourceSessionId: unwrapCloneSessionId(sourceSessionId),

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.1.1",
+        version: "0.1.3",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.1.1",
+        version: "0.1.3",
         assistantTools: [
             {
                 type: "function",


### PR DESCRIPTION
This pull request introduces enhanced shell integration for session management, improves working directory tracking across platforms, and adds sanitization of terminal output for session replay. The main themes are improved shell lifecycle tracking, robust CWD resolution, and better session cloning behavior.

Shell integration and command lifecycle tracking:

* Added shell integration for Bash (including WSL on Windows) that emits OSC 133 markers for command start, finish, and working directory changes. The integration now sends base64-encoded CWD markers to allow robust tracking of the shell's current directory. (`crates/amux-daemon/src/pty_session.rs`) [[1]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR638-R648) [[2]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR754-R756)
* Updated the PTY session struct and session reader loop to track the last active command and shell-reported CWD, using new markers parsed from terminal output. (`crates/amux-daemon/src/pty_session.rs`) [[1]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR40-R43) [[2]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR68) [[3]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR140-R143) [[4]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR157-R158) [[5]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR172-R173) [[6]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR196-R197) [[7]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cL299-R336) [[8]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR373-R379) [[9]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR391-R392) [[10]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR439) [[11]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR455) [[12]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cR524-R526)

Working directory resolution and cross-platform support:

* Improved CWD resolution logic to prioritize shell integration markers, then OS-level queries, then fallback to startup CWD. Added support for passing CWD into shells on Windows and WSL, including conversion of Windows paths for WSL compatibility. (`crates/amux-daemon/src/pty_session.rs`) [[1]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cL91-R113) [[2]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cL695-R860)
* Refactored shell command configuration to inject the Bash RC file for integration, and to handle CWD setting appropriately for different platforms and shell types. (`crates/amux-daemon/src/pty_session.rs`) [[1]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cL627-R742) [[2]](diffhunk://#diff-ce9b412cc3b845a664abe33fc9b422309fd7befda14f89e3e1f37068aef98a9cL695-R860)

Session cloning and terminal replay improvements:

* Modified session cloning to accept a fallback CWD and return the active command, and changed the CLI and client code to support these new behaviors. (`crates/amux-cli/src/client.rs`, `crates/amux-cli/src/main.rs`) [[1]](diffhunk://#diff-33913b6389fb9e8e8508bf08dcb08d896bfc6697c671e60a372da9d12c8f8c8fL224-R237) [[2]](diffhunk://#diff-424855102c6b0376e4f6f1d34e7fc1c4ae36873acb46cf908c69394c7600ba2eR54-R56) [[3]](diffhunk://#diff-424855102c6b0376e4f6f1d34e7fc1c4ae36873acb46cf908c69394c7600ba2eR200-R206)
* Added a function to sanitize terminal scrollback before replaying it into a new session, removing disruptive terminal-to-host CSI sequences. (`crates/amux-daemon/src/pty_session.rs`)
* Added a nudge (resize) after subscribing to a session in the bridge to ensure shells redraw their prompt, especially in WSL scenarios. (`crates/amux-cli/src/client.rs`)

Version update:

* Bumped workspace package version in `Cargo.toml` to `0.1.3`. (`Cargo.toml`)