### PR TITLE
v0.2.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 license = "MIT"
 authors = ["tamux contributors"]

--- a/crates/amux-daemon/src/agent/stalled_turns/recovery.rs
+++ b/crates/amux-daemon/src/agent/stalled_turns/recovery.rs
@@ -8,6 +8,27 @@ impl AgentEngine {
     ) -> Result<()> {
         let attempt = candidate.retries_sent.saturating_add(1);
         let recovery_message = stalled_turn_system_message(candidate, attempt);
+        let prior_user_message = {
+            let threads = self.threads.read().await;
+            let Some(thread) = threads.get(&candidate.thread_id) else {
+                anyhow::bail!(
+                    "thread {} disappeared before stalled-turn retry",
+                    candidate.thread_id
+                );
+            };
+            thread
+                .messages
+                .iter()
+                .rev()
+                .find(|message| message.role == MessageRole::User)
+                .map(|message| message.content.clone())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "thread {} has no prior user message for stalled-turn retry",
+                        candidate.thread_id
+                    )
+                })?
+        };
 
         {
             let mut threads = self.threads.write().await;
@@ -39,18 +60,8 @@ impl AgentEngine {
             ),
         );
 
-        self.send_message_inner(
-            Some(&candidate.thread_id),
-            "continue",
-            candidate.task_id.as_deref(),
-            None,
-            None,
-            None,
-            None,
-            None,
-            false,
-        )
-        .await?;
+        self.resend_existing_user_message(&candidate.thread_id, &prior_user_message)
+            .await?;
         Ok(())
     }
 

--- a/crates/amux-daemon/src/agent/stalled_turns/tests.rs
+++ b/crates/amux-daemon/src/agent/stalled_turns/tests.rs
@@ -348,10 +348,13 @@ async fn supervise_stalled_turns_retries_with_system_recovery_and_continue() {
         message.role == MessageRole::System
             && message.content.contains("WELES stalled-turn recovery")
     }));
-    assert!(thread
-        .messages
-        .iter()
-        .any(|message| { message.role == MessageRole::User && message.content == "continue" }));
+    assert!(
+        !thread
+            .messages
+            .iter()
+            .any(|message| { message.role == MessageRole::User && message.content == "continue" }),
+        "stalled-turn retries should not append a synthetic user 'continue' message"
+    );
     assert!(thread.messages.iter().any(|message| {
         message.role == MessageRole::Assistant && message.content.contains("Recovered.")
     }));

--- a/crates/amux-daemon/src/agent/task_prompt.rs
+++ b/crates/amux-daemon/src/agent/task_prompt.rs
@@ -228,13 +228,17 @@ pub(super) fn skills_dir(agent_data_dir: &std::path::Path) -> std::path::PathBuf
         .join("skills")
 }
 
+fn builtin_skills_source_dir() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../skills")
+}
+
 /// Seed built-in skill documents into `~/.tamux/skills/builtin/`.
 pub(super) fn seed_builtin_skills(agent_data_dir: &std::path::Path) {
     let root = skills_dir(agent_data_dir);
-    let source = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../../../../skills"));
+    let source = builtin_skills_source_dir();
     let target = root.join("builtin");
 
-    match seed_skills_tree(source, &target) {
+    match seed_skills_tree(&source, &target) {
         Ok(count) => tracing::debug!("seeded {} built-in skills into {}", count, target.display()),
         Err(e) => tracing::warn!(
             "failed to seed built-in skills from {} to {}: {e}",
@@ -344,6 +348,7 @@ pub async fn load_config_from_history(
 mod tests {
     use super::*;
     use crate::agent::agent_identity::{MAIN_AGENT_ID, RADOGOST_AGENT_ID};
+    use tempfile::tempdir;
 
     #[test]
     fn memory_paths_for_main_scope_falls_back_to_legacy_root() {
@@ -378,5 +383,33 @@ mod tests {
                 .join("SOUL.md")
         );
         assert_eq!(paths.user_path, shared_user_root.join("USER.md"));
+    }
+
+    #[test]
+    fn seed_builtin_skills_copies_repo_skill_docs() {
+        let temp = tempdir().expect("tempdir should succeed");
+        let agent_data_dir = temp.path().join("agent");
+
+        seed_builtin_skills(&agent_data_dir);
+
+        let builtin_root = skills_dir(&agent_data_dir).join("builtin");
+        assert!(
+            builtin_root.join("README.md").exists(),
+            "expected built-in skills seed to copy the repo skills README"
+        );
+        assert!(
+            builtin_root.join("operating").join("thread-compaction.md").exists(),
+            "expected built-in skills seed to copy nested skill docs"
+        );
+    }
+
+    #[test]
+    fn builtin_skills_source_dir_points_at_repo_skills_tree() {
+        let expected = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../skills");
+        assert_eq!(builtin_skills_source_dir(), expected);
+        assert!(
+            builtin_skills_source_dir().join("README.md").exists(),
+            "expected built-in skills source dir to resolve to the repo skills tree"
+        );
     }
 }

--- a/crates/amux-tui/src/widgets/chat/part2.rs
+++ b/crates/amux-tui/src/widgets/chat/part2.rs
@@ -265,7 +265,7 @@ fn assistant_responder_labels(
         if msg.role == MessageRole::Assistant {
             labels[idx] = responder.clone();
         }
-        if let Some(event) = parse_handoff_responder_event(&msg.content) {
+        if let Some(event) = handoff_responder_event_for_message(msg) {
             if event.to_agent_name.is_some() {
                 responder = event.to_agent_name;
             }
@@ -279,9 +279,16 @@ fn initial_responder_name(thread: &crate::state::chat::AgentThread) -> Option<St
     thread
         .messages
         .iter()
-        .find_map(|msg| parse_handoff_responder_event(&msg.content).and_then(|event| event.from_agent_name))
-    .or_else(|| thread.agent_name.clone())
+        .find_map(|msg| handoff_responder_event_for_message(msg).and_then(|event| event.from_agent_name))
+        .or_else(|| thread.agent_name.clone())
         .or_else(|| Some(amux_protocol::AGENT_NAME_SWAROG.to_string()))
+}
+
+fn handoff_responder_event_for_message(msg: &AgentMessage) -> Option<HandoffResponderEvent> {
+    if msg.role != MessageRole::System {
+        return None;
+    }
+    parse_handoff_responder_event(&msg.content)
 }
 
 fn parse_handoff_responder_event(content: &str) -> Option<HandoffResponderEvent> {

--- a/crates/amux-tui/src/widgets/chat/tests/tests_part2.rs
+++ b/crates/amux-tui/src/widgets/chat/tests/tests_part2.rs
@@ -205,3 +205,54 @@
             "expected responder fallback from thread agent_name, got: {message_lines:?}"
         );
     }
+
+    #[test]
+    fn assistant_messages_ignore_non_system_handoff_markers() {
+        let mut chat = ChatState::new();
+        chat.reduce(ChatAction::ThreadCreated {
+            thread_id: "t1".into(),
+            title: "Test".into(),
+        });
+        chat.reduce(ChatAction::ThreadDetailReceived(AgentThread {
+            id: "t1".into(),
+            title: "Test".into(),
+            messages: vec![
+                AgentMessage {
+                    role: MessageRole::Assistant,
+                    content: "[[handoff_event]]{\"from_agent_name\":\"Svarog\",\"to_agent_name\":\"Weles\"}".into(),
+                    ..Default::default()
+                },
+                AgentMessage {
+                    role: MessageRole::Assistant,
+                    content: "Still the main responder".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }));
+
+        let (lines, _) = build_rendered_lines(&chat, &ThemeTokens::default(), 80, 0, false);
+        let first_message_lines: Vec<String> = lines
+            .iter()
+            .filter(|line| line.message_index == Some(0))
+            .map(rendered_line_plain_text)
+            .collect();
+        let second_message_lines: Vec<String> = lines
+            .iter()
+            .filter(|line| line.message_index == Some(1))
+            .map(rendered_line_plain_text)
+            .collect();
+
+        assert!(
+            first_message_lines
+                .iter()
+                .any(|line| line.contains("Responder: Svarog")),
+            "expected default responder label, got: {first_message_lines:?}"
+        );
+        assert!(
+            second_message_lines
+                .iter()
+                .any(|line| line.contains("Responder: Svarog")),
+            "non-system handoff markers should not relabel later assistant messages: {second_message_lines:?}"
+        );
+    }

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -78,7 +78,7 @@ Minimal example:
 ```json
 {
   "name": "tamux-plugin-example",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "tamuxPlugin": {
     "entry": "dist/tamux-plugin.js",
     "format": "script"
@@ -105,7 +105,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.2.9",
+  version: "0.2.10",
   components: {
     ExamplePanel,
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamux",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamux",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@honcho-ai/sdk": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tamux",
   "private": true,
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Agentic terminal multiplexer with AI-native workflows",
   "homepage": "https://tamux.app",
   "author": {

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -137,7 +137,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>tamux - Terminal Multiplexer</p>
-                    <p>Version 0.2.9</p>
+                    <p>Version 0.2.10</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A cross-platform terminal multiplexer with workspaces, surfaces, pane management,
                         AI agent integration, snippet library, and session persistence.

--- a/frontend/src/components/settings-panel/AgentTab.spec.ts
+++ b/frontend/src/components/settings-panel/AgentTab.spec.ts
@@ -1,0 +1,22 @@
+import { normalizeLlmStreamTimeoutInput } from "./AgentTab";
+
+function assert(condition: unknown, message: string): void {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+assert(
+    normalizeLlmStreamTimeoutInput("30.5") === 30,
+    "Decimal timeout input should coerce to an in-range integer",
+);
+
+assert(
+    normalizeLlmStreamTimeoutInput("9999") === 1800,
+    "Timeout input should clamp to the maximum allowed value",
+);
+
+assert(
+    normalizeLlmStreamTimeoutInput("29") === 30,
+    "Timeout input should clamp to the minimum allowed value",
+);

--- a/frontend/src/components/settings-panel/AgentTab.tsx
+++ b/frontend/src/components/settings-panel/AgentTab.tsx
@@ -8,6 +8,14 @@ import { useAgentStore } from "../../lib/agentStore";
 import { deriveOpenAICodexAuthUi } from "./openaiSubscriptionAuth";
 import { addBtnStyle, ModelSelector, NumberInput, PasswordInput, Section, SelectInput, SettingRow, TextInput, Toggle, inputStyle, smallBtnStyle } from "./shared";
 
+export function normalizeLlmStreamTimeoutInput(value: string): number | null {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed)) {
+        return null;
+    }
+    return Math.min(1800, Math.max(30, parsed));
+}
+
 export function AgentTab({
     settings, updateSetting, resetSettings,
 }: {
@@ -757,8 +765,8 @@ export function AgentTab({
                         max={1800}
                         step={10}
                         onChange={(event) => {
-                            const nextValue = Number.parseFloat(event.target.value);
-                            if (!Number.isNaN(nextValue)) {
+                            const nextValue = normalizeLlmStreamTimeoutInput(event.target.value);
+                            if (nextValue !== null) {
                                 updateSetting("llm_stream_chunk_timeout_secs", nextValue);
                             }
                         }}

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.2.9",
+        version: "0.2.10",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.2.9",
+        version: "0.2.10",
         assistantTools: [
             {
                 type: "function",

--- a/npm-package/README.md
+++ b/npm-package/README.md
@@ -1,0 +1,18 @@
+# tamux
+
+This npm package installs the tamux launcher and downloads the platform-specific tamux binaries on install or first run.
+
+Full project documentation lives in the main repository README:
+
+- https://github.com/mkurman/tamux/blob/main/README.md
+
+Project homepage:
+
+- https://tamux.app
+
+Quick start:
+
+```bash
+npm install -g tamux
+tamux --help
+```

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamux",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "The Agent That Lives - daemon-first AI agent runtime",
   "license": "MIT",
   "homepage": "https://tamux.app",

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -25,7 +25,6 @@
   "files": [
     "install.js",
     "bin/",
-    "../README.md",
-    "../LICENSE"
+    "README.md"
   ]
 }

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -137,6 +137,7 @@ PY
 
 # Detect platform
 OS="$(uname -s)"
+OS_SLUG="$(printf '%s' "$OS" | tr '[:upper:]' '[:lower:]')"
 EXE=""
 PLATFORM_DIR="linux"
 if [[ "$OS" == *MINGW* ]] || [[ "$OS" == *MSYS* ]] || [[ "$OS" == *CYGWIN* ]]; then
@@ -336,8 +337,8 @@ done
 
 if [[ ${#bundle_artifacts[@]} -gt 0 ]]; then
     notes_file="$OUT_DIR/RELEASE_NOTES.md"
-    checksums_file="$OUT_DIR/SHA256SUMS-${OS,,}-${ARCH}.txt"
-    bundle_file="$OUT_DIR/tamux-${APP_VERSION}-${OS,,}-${ARCH}.zip"
+    checksums_file="$OUT_DIR/SHA256SUMS-${OS_SLUG}-${ARCH}.txt"
+    bundle_file="$OUT_DIR/tamux-${APP_VERSION}-${OS_SLUG}-${ARCH}.zip"
 
     generate_release_notes_if_missing "$notes_file" "${bundle_artifacts[@]}"
     write_checksums_file "$checksums_file" "${bundle_artifacts[@]}"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -337,8 +337,12 @@ done
 
 if [[ ${#bundle_artifacts[@]} -gt 0 ]]; then
     notes_file="$OUT_DIR/RELEASE_NOTES.md"
-    checksums_file="$OUT_DIR/SHA256SUMS-${OS_SLUG}-${ARCH}.txt"
-    bundle_file="$OUT_DIR/tamux-${APP_VERSION}-${OS_SLUG}-${ARCH}.zip"
+    artifact_os_name="$OS"
+    if [[ "$PLATFORM_DIR" == "macos" ]]; then
+        artifact_os_name="$OS_SLUG"
+    fi
+    checksums_file="$OUT_DIR/SHA256SUMS-${artifact_os_name}-${ARCH}.txt"
+    bundle_file="$OUT_DIR/tamux-${APP_VERSION}-${artifact_os_name}-${ARCH}.zip"
 
     generate_release_notes_if_missing "$notes_file" "${bundle_artifacts[@]}"
     write_checksums_file "$checksums_file" "${bundle_artifacts[@]}"


### PR DESCRIPTION
This pull request delivers version 0.2.10 of tamux, introducing several bug fixes, improvements to agent recovery and skill seeding, enhanced test coverage, and UI robustness. It also updates version numbers across the project and refines packaging for npm and release scripts.

**Agent recovery and skill seeding improvements:**

* Changed stalled-turn recovery to resend the actual prior user message instead of injecting a synthetic "continue" message, improving conversation fidelity and adding error handling for missing user messages (`crates/amux-daemon/src/agent/stalled_turns/recovery.rs`, `crates/amux-daemon/src/agent/stalled_turns/tests.rs`). [[1]](diffhunk://#diff-f74895a93f7f3df5d0041ae538e0d3abd6b0a6ab5bf27070f261c3897fd6366dR11-R31) [[2]](diffhunk://#diff-f74895a93f7f3df5d0041ae538e0d3abd6b0a6ab5bf27070f261c3897fd6366dL42-R63) [[3]](diffhunk://#diff-5ec4442aa1741c3dcbdcfe0970bc724d89af7e47e45c98b5f5558e221da98702L351-R357)
* Refactored built-in skills seeding logic for clarity, added tests to ensure skills are copied correctly, and improved path resolution (`crates/amux-daemon/src/agent/task_prompt.rs`). [[1]](diffhunk://#diff-642e35b1b4fa4158fb3fa72894e78633db096af769673be4ffaeb96b4906cdffR231-R241) [[2]](diffhunk://#diff-642e35b1b4fa4158fb3fa72894e78633db096af769673be4ffaeb96b4906cdffR351) [[3]](diffhunk://#diff-642e35b1b4fa4158fb3fa72894e78633db096af769673be4ffaeb96b4906cdffR387-R414)

**User interface and UX fixes:**

* Improved responder labeling in the TUI: only system messages trigger handoff relabeling, preventing non-system handoff markers from affecting assistant message labels; added a regression test (`crates/amux-tui/src/widgets/chat/part2.rs`, `crates/amux-tui/src/widgets/chat/tests/tests_part2.rs`). [[1]](diffhunk://#diff-12b12748489b6dbb03990d2380ab55181623a0ba7514b15aaf93a7543bf75665L268-R268) [[2]](diffhunk://#diff-12b12748489b6dbb03990d2380ab55181623a0ba7514b15aaf93a7543bf75665L282-R293) [[3]](diffhunk://#diff-56f212be4492a57db80d15490a703b6fd71a9cba81ef5304acef5344b9f43809R208-R258)
* Enhanced input normalization for LLM stream timeout settings in the frontend, clamping values to valid bounds and adding tests (`frontend/src/components/settings-panel/AgentTab.tsx`, `frontend/src/components/settings-panel/AgentTab.spec.ts`). [[1]](diffhunk://#diff-d16386e5e516c481bc63e00c6c42f0ea4655a58815d405a3617fbbe9a2cfe982R11-R18) [[2]](diffhunk://#diff-d16386e5e516c481bc63e00c6c42f0ea4655a58815d405a3617fbbe9a2cfe982L760-R769) [[3]](diffhunk://#diff-6d17e8c7785d0a3ab6ac2281f617c3f84ce2790061df82e943f0c2a7d8d40492R1-R22)

**Versioning and packaging updates:**

* Bumped version to 0.2.10 across all Rust crates, frontend, plugins, and documentation (`Cargo.toml`, `frontend/package.json`, `frontend/package-lock.json`, `docs/plugin-development.md`, `frontend/src/components/settings-panel/AboutTab.tsx`, `frontend/src/plugins/ai-training/registerPlugin.ts`, `frontend/src/plugins/coding-agents/registerPlugin.ts`, `npm-package/package.json`). [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L13-R13) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9) [[4]](diffhunk://#diff-f86abbd74d48b08360106f915df7e32cb28bee57f154198f151a6274b05b1fd0L81-R81) [[5]](diffhunk://#diff-f86abbd74d48b08360106f915df7e32cb28bee57f154198f151a6274b05b1fd0L108-R108) [[6]](diffhunk://#diff-5b6294f09c85d1fb2b0f7e442e35e29853453863a2c77fd4dc401d74e565bd60L140-R140) [[7]](diffhunk://#diff-135b242f86713bdcda51a03ffbf25bcf337e319e09cd124db23718e503e4c026L87-R87) [[8]](diffhunk://#diff-717f73d06bc5e8fd3d41ab91a9280002adf096e8b12399d03fd54ce327f3350fL86-R86) [[9]](diffhunk://#diff-644eeeb901f63bf607ad522e934b62a9fa61c252872d74cc99e5f5e078b896d9L3-R3)
* Added a README and refined packaging for the npm package, ensuring correct inclusion of files and documentation (`npm-package/README.md`, `npm-package/package.json`). [[1]](diffhunk://#diff-149cf0976015b7979f770438830e7b011e8e0c8c9773d4d031aa02e194ae9132R1-R18) [[2]](diffhunk://#diff-644eeeb901f63bf607ad522e934b62a9fa61c252872d74cc99e5f5e078b896d9L28-R28)
* Improved release script to handle OS naming more robustly for artifact generation (`scripts/build-release.sh`). [[1]](diffhunk://#diff-8e98a9e724228af47b978fb2be02a8154e0925b66b072cec9e848a2543f9eee2R140) [[2]](diffhunk://#diff-8e98a9e724228af47b978fb2be02a8154e0925b66b072cec9e848a2543f9eee2L339-R345)