### PR TITLE
feat: Update version to 0.2.11 across all relevant files and enhance …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,338 @@
+name: Release Build
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  NODE_VERSION: '22'
+  RUST_VERSION: stable
+
+jobs:
+  # ================================================================
+  # Linux x64 — Rust cross-compile + Electron packaging
+  # ================================================================
+  build-linux-x64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Install cross
+        run: cargo install cross --locked
+
+      - name: Rust build
+        run: cross build --release --target x86_64-unknown-linux-gnu
+
+      - name: Collect Linux binaries
+        run: |
+          mkdir -p dist-release/linux
+          for bin in tamux-daemon tamux tamux-tui tamux-mcp tamux-gateway; do
+            cp target/x86_64-unknown-linux-gnu/release/$bin dist-release/linux/
+          done
+
+      - name: Build frontend
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+        working-directory: frontend
+
+      - name: npm install + build
+        run: npm ci && npm run build
+        working-directory: frontend
+
+      - name: Copy binaries to frontend/dist
+        run: |
+          cp dist-release/linux/tamux-daemon frontend/dist/
+          cp dist-release/linux/tamux frontend/dist/
+          cp dist-release/linux/tamux-tui frontend/dist/
+          cp dist-release/linux/tamux-mcp frontend/dist/
+          cp dist-release/linux/tamux-gateway frontend/dist/
+
+      - name: Electron package (Linux AppImage + deb)
+        run: npx electron-builder --linux AppImage deb
+        working-directory: frontend
+
+      - name: Package Linux binaries
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          cd dist-release/linux
+          ZIP="tamux-$VERSION-linux-x86_64.zip"
+          zip "$ZIP" tamux-daemon tamux tamux-tui tamux-mcp tamux-gateway
+          sha256sum "$ZIP" > "SHA256SUMS-linux-x86_64.txt"
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-x64
+          path: |
+            dist-release/linux/*.zip
+            dist-release/linux/SHA256SUMS*.txt
+            frontend/release/*.AppImage
+            frontend/release/*.deb
+          retention-days: 5
+
+  # ================================================================
+  # Windows x64 — Rust cross-compile + Electron packaging
+  # ================================================================
+  build-windows-x64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: x86_64-pc-windows-gnu
+
+      - name: Install mingw
+        run: sudo apt-get install -y mingw-w64
+
+      - name: Rust build (Windows cross-compile)
+        run: cargo build --release --target x86_64-pc-windows-gnu
+
+      - name: Collect Windows binaries
+        run: |
+          mkdir -p dist-release/windows
+          for bin in tamux-daemon tamux tamux-tui tamux-mcp tamux-gateway; do
+            cp target/x86_64-pc-windows-gnu/release/$bin.exe dist-release/windows/$bin.exe
+          done
+
+      - name: Build frontend
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+        working-directory: frontend
+
+      - name: npm install + build
+        run: npm ci && npm run build
+        working-directory: frontend
+
+      - name: Copy binaries to frontend/dist
+        run: |
+          cp dist-release/windows/tamux-daemon.exe frontend/dist/
+          cp dist-release/windows/tamux.exe frontend/dist/
+          cp dist-release/windows/tamux-tui.exe frontend/dist/
+          cp dist-release/windows/tamux-mcp.exe frontend/dist/
+          cp dist-release/windows/tamux-gateway.exe frontend/dist/
+
+      - name: Electron package (Windows portable + nsis)
+        run: npx electron-builder --win portable nsis
+        working-directory: frontend
+
+      - name: Package Windows binaries
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          cd dist-release/windows
+          ZIP="tamux-$VERSION-windows-x64.zip"
+          zip "$ZIP" tamux-daemon.exe tamux.exe tamux-tui.exe tamux-mcp.exe tamux-gateway.exe
+          sha256sum "$ZIP" > "SHA256SUMS-windows-x64.txt"
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-x64
+          path: |
+            dist-release/windows/*.zip
+            dist-release/windows/SHA256SUMS*.txt
+            frontend/release/*.exe
+          retention-days: 5
+
+  # ================================================================
+  # macOS x64 (Intel) — native build
+  # ================================================================
+  build-darwin-x64:
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: x86_64-apple-darwin
+
+      - name: Rust build
+        run: cargo build --release --target x86_64-apple-darwin
+
+      - name: Collect macOS Intel binaries
+        run: |
+          mkdir -p dist-release/macos
+          for bin in tamux-daemon tamux tamux-tui tamux-mcp tamux-gateway; do
+            cp target/x86_64-apple-darwin/release/$bin dist-release/macos/
+          done
+
+      - name: Build frontend
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+        working-directory: frontend
+
+      - name: npm install + build
+        run: npm ci && npm run build
+        working-directory: frontend
+
+      - name: Copy binaries to frontend/dist
+        run: |
+          cp dist-release/macos/tamux-daemon frontend/dist/
+          cp dist-release/macos/tamux frontend/dist/
+          cp dist-release/macos/tamux-tui frontend/dist/
+          cp dist-release/macos/tamux-mcp frontend/dist/
+          cp dist-release/macos/tamux-gateway frontend/dist/
+
+      - name: Electron package (macOS dmg + zip)
+        run: npx electron-builder --mac dmg zip
+        working-directory: frontend
+
+      - name: Package macOS Intel binaries
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          cd dist-release/macos
+          ZIP="tamux-$VERSION-darwin-x86_64.zip"
+          zip "$ZIP" tamux-daemon tamux tamux-tui tamux-mcp tamux-gateway
+          sha256sum "$ZIP" > "SHA256SUMS-darwin-x86_64.txt"
+
+      - name: Upload macOS Intel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: darwin-x64
+          path: |
+            dist-release/macos/*.zip
+            dist-release/macos/SHA256SUMS*.txt
+            frontend/release/*.dmg
+            frontend/release/*.zip
+          retention-days: 5
+
+  # ================================================================
+  # macOS arm64 (Apple Silicon) — native build
+  # ================================================================
+  build-darwin-arm64:
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: aarch64-apple-darwin
+
+      - name: Rust build
+        run: cargo build --release --target aarch64-apple-darwin
+
+      - name: Collect macOS ARM64 binaries
+        run: |
+          mkdir -p dist-release/macos
+          for bin in tamux-daemon tamux tamux-tui tamux-mcp tamux-gateway; do
+            cp target/aarch64-apple-darwin/release/$bin dist-release/macos/
+          done
+
+      - name: Build frontend
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+        working-directory: frontend
+
+      - name: npm install + build
+        run: npm ci && npm run build
+        working-directory: frontend
+
+      - name: Copy binaries to frontend/dist
+        run: |
+          cp dist-release/macos/tamux-daemon frontend/dist/
+          cp dist-release/macos/tamux frontend/dist/
+          cp dist-release/macos/tamux-tui frontend/dist/
+          cp dist-release/macos/tamux-mcp frontend/dist/
+          cp dist-release/macos/tamux-gateway frontend/dist/
+
+      - name: Electron package (macOS dmg + zip)
+        run: npx electron-builder --mac dmg zip
+        working-directory: frontend
+
+      - name: Package macOS ARM64 binaries
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          cd dist-release/macos
+          ZIP="tamux-$VERSION-darwin-arm64.zip"
+          zip "$ZIP" tamux-daemon tamux tamux-tui tamux-mcp tamux-gateway
+          sha256sum "$ZIP" > "SHA256SUMS-darwin-arm64.txt"
+
+      - name: Upload macOS ARM64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: darwin-arm64
+          path: |
+            dist-release/macos/*.zip
+            dist-release/macos/SHA256SUMS*.txt
+            frontend/release/*.dmg
+            frontend/release/*.zip
+          retention-days: 5
+
+  # ================================================================
+  # Release — collect all artifacts, create GitHub Release
+  # ================================================================
+  release:
+    needs: [build-linux-x64, build-windows-x64, build-darwin-x64, build-darwin-arm64]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: '*'
+          merge-multiple: false
+
+      - name: List artifacts
+        run: find artifacts -type f | sort
+
+      - name: Create combined SHA256SUMS
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          {
+            echo "# SHA256SUMS for tamux v${VERSION}"
+            echo ""
+          } > SHA256SUMS.txt
+          for f in $(find artifacts -name 'SHA256SUMS*.txt' | sort); do
+            echo "" >> SHA256SUMS.txt
+            echo "### $(basename $(dirname $f))" >> SHA256SUMS.txt
+            cat "$f" >> SHA256SUMS.txt
+          done
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            artifacts/**/*.zip
+            artifacts/**/SHA256SUMS*.txt
+            artifacts/**/*.AppImage
+            artifacts/**/*.deb
+            artifacts/**/*.dmg
+            SHA256SUMS.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,7 +4376,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tamux-cli"
-version = "0.2.9"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "base64",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-daemon"
-version = "0.2.9"
+version = "0.2.11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-gateway"
-version = "0.2.9"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "futures",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-mcp"
-version = "0.2.9"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "futures",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-protocol"
-version = "0.2.9"
+version = "0.2.11"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-tui"
-version = "0.2.9"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 license = "MIT"
 authors = ["tamux contributors"]

--- a/crates/amux-daemon/src/agent/agent_loop/send_message/finalize.rs
+++ b/crates/amux-daemon/src/agent/agent_loop/send_message/finalize.rs
@@ -154,6 +154,9 @@ impl<'a> SendMessageRunner<'a> {
             )
             .await;
         self.engine
+            .maybe_auto_send_gateway_thread_response(&self.tid)
+            .await;
+        self.engine
             .update_thread_upstream_state(
                 &self.tid,
                 &self.config.provider,

--- a/crates/amux-daemon/src/agent/agent_loop/send_message/tool_calls.rs
+++ b/crates/amux-daemon/src/agent/agent_loop/send_message/tool_calls.rs
@@ -60,6 +60,9 @@ impl<'a> SendMessageRunner<'a> {
             .await;
         self.engine.persist_thread_by_id(&self.tid).await;
         self.engine
+            .maybe_auto_send_gateway_thread_response(&self.tid)
+            .await;
+        self.engine
             .update_thread_upstream_state(
                 &self.tid,
                 &self.config.provider,

--- a/crates/amux-daemon/src/agent/gateway_loop/message_helpers.rs
+++ b/crates/amux-daemon/src/agent/gateway_loop/message_helpers.rs
@@ -16,28 +16,64 @@ impl AgentEngine {
         msg: &gateway::IncomingMessage,
         response_text: &str,
     ) -> ToolResult {
-        let auto_tool = ToolCall::with_default_weles_review(
-            format!("{tool_id_prefix}_{}", uuid::Uuid::new_v4()),
-            ToolFunction {
-                name: reply_tool_name.to_string(),
-                arguments: gateway_reply_args(&msg.platform, &msg.channel, response_text)
-                    .to_string(),
-            },
-        );
-        let tool_result = Box::pin(tool_executor::execute_tool(
-            &auto_tool,
+        let tool_call_id = format!("{tool_id_prefix}_{}", uuid::Uuid::new_v4());
+        let args = gateway_reply_args(&msg.platform, &msg.channel, response_text);
+        match crate::agent::tool_executor::execute_gateway_message(
+            reply_tool_name,
+            &args,
             self,
-            thread_id,
-            None,
-            &self.session_manager,
-            None,
-            &self.event_tx,
-            &self.data_dir,
             &self.http_client,
-            None,
-        ))
-        .await;
-        tool_result
+        )
+        .await
+        {
+            Ok(content) => ToolResult {
+                tool_call_id,
+                name: reply_tool_name.to_string(),
+                content,
+                is_error: false,
+                weles_review: None,
+                pending_approval: None,
+            },
+            Err(error) => ToolResult {
+                tool_call_id,
+                name: reply_tool_name.to_string(),
+                content: error.to_string(),
+                is_error: true,
+                weles_review: None,
+                pending_approval: None,
+            },
+        }
+    }
+
+    async fn gateway_message_target_for_thread(
+        &self,
+        thread_id: &str,
+    ) -> Option<gateway::IncomingMessage> {
+        let channel_key = {
+            let gateway_threads = self.gateway_threads.read().await;
+            gateway_threads.iter().find_map(|(channel_key, mapped_thread_id)| {
+                (mapped_thread_id == thread_id).then(|| channel_key.clone())
+            })
+        }?;
+
+        let (platform, channel) = channel_key.split_once(':')?;
+        Some(gateway::IncomingMessage {
+            platform: platform.to_string(),
+            sender: String::new(),
+            content: String::new(),
+            channel: channel.to_string(),
+            message_id: None,
+            thread_context: None,
+        })
+    }
+
+    pub(in crate::agent) async fn maybe_auto_send_gateway_thread_response(&self, thread_id: &str) {
+        let Some(msg) = self.gateway_message_target_for_thread(thread_id).await else {
+            return;
+        };
+        let (_, reply_tool_name) = gateway_reply_tool(&msg.platform, &msg.channel);
+        self.auto_send_gateway_response(thread_id, &msg, reply_tool_name)
+            .await;
     }
 
     pub(super) async fn send_gateway_timeout_fallback(
@@ -334,28 +370,15 @@ impl AgentEngine {
                 "gateway: agent forgot to call send tool, auto-sending response"
             );
 
-            let auto_tool = ToolCall::with_default_weles_review(
-                format!("auto_{}", uuid::Uuid::new_v4()),
-                ToolFunction {
-                    name: reply_tool_name.to_string(),
-                    arguments: gateway_reply_args(&msg.platform, &msg.channel, &response_text)
-                        .to_string(),
-                },
-            );
-
-            let _ = Box::pin(tool_executor::execute_tool(
-                &auto_tool,
-                self,
-                "",
-                None,
-                &self.session_manager,
-                None,
-                &self.event_tx,
-                &self.data_dir,
-                &self.http_client,
-                None,
-            ))
-            .await;
+            let _ = self
+                .send_gateway_platform_tool(
+                    thread_id,
+                    "auto",
+                    reply_tool_name,
+                    msg,
+                    &response_text,
+                )
+                .await;
         }
     }
 
@@ -416,8 +439,6 @@ impl AgentEngine {
                 {
                     tracing::warn!(channel_key = %channel_key, %error, "gateway: failed to persist thread binding");
                 }
-                self.auto_send_gateway_response(&thread_id, msg, reply_tool_name)
-                    .await;
             }
         }
     }

--- a/crates/amux-daemon/src/agent/gateway_loop/state.rs
+++ b/crates/amux-daemon/src/agent/gateway_loop/state.rs
@@ -264,15 +264,43 @@ fn latest_gateway_turn_slice(messages: &[AgentMessage]) -> &[AgentMessage] {
     &messages[turn_start..]
 }
 
+fn is_gateway_send_tool_message(message: &AgentMessage) -> bool {
+    message.role == MessageRole::Tool
+        && message
+            .tool_name
+            .as_deref()
+            .map(|name| name.starts_with("send_"))
+            .unwrap_or(false)
+}
+
+fn assistant_message_has_gateway_send_tool_call(message: &AgentMessage) -> bool {
+    message
+        .tool_calls
+        .as_ref()
+        .map(|tool_calls| {
+            tool_calls
+                .iter()
+                .any(|tool_call| tool_call.function.name.starts_with("send_"))
+        })
+        .unwrap_or(false)
+}
+
 pub(super) fn gateway_turn_used_send_tool(messages: &[AgentMessage]) -> bool {
-    latest_gateway_turn_slice(messages).iter().any(|message| {
-        message.role == MessageRole::Tool
-            && message
-                .tool_name
-                .as_deref()
-                .map(|name| name.starts_with("send_"))
-                .unwrap_or(false)
-    })
+    let turn = latest_gateway_turn_slice(messages);
+    let Some(latest_assistant_index) = turn
+        .iter()
+        .rposition(|message| message.role == MessageRole::Assistant && !message.content.is_empty())
+    else {
+        return turn.iter().any(is_gateway_send_tool_message);
+    };
+
+    if assistant_message_has_gateway_send_tool_call(&turn[latest_assistant_index]) {
+        return true;
+    }
+
+    turn[latest_assistant_index + 1..]
+        .iter()
+        .any(is_gateway_send_tool_message)
 }
 
 pub(super) fn latest_gateway_turn_assistant_response(messages: &[AgentMessage]) -> Option<String> {

--- a/crates/amux-daemon/src/agent/gateway_loop/tests/basic.rs
+++ b/crates/amux-daemon/src/agent/gateway_loop/tests/basic.rs
@@ -214,6 +214,88 @@ fn gateway_auto_send_ignores_historic_send_tools_from_prior_turns() {
 }
 
 #[test]
+fn gateway_auto_send_keeps_latest_assistant_message_pending_after_earlier_send_tool() {
+    let messages = vec![
+        AgentMessage::user("Can you check this?", 1),
+        AgentMessage {
+            id: "assistant-1".to_string(),
+            role: MessageRole::Assistant,
+            content: "On it, give me a moment...".to_string(),
+            tool_calls: None,
+            tool_call_id: None,
+            tool_name: None,
+            tool_arguments: None,
+            tool_status: None,
+            weles_review: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            provider: None,
+            model: None,
+            api_transport: None,
+            response_id: None,
+            reasoning: None,
+            message_kind: AgentMessageKind::Normal,
+            compaction_strategy: None,
+            compaction_payload: None,
+            timestamp: 2,
+        },
+        AgentMessage {
+            id: "tool-1".to_string(),
+            role: MessageRole::Tool,
+            content: "Discord message sent".to_string(),
+            tool_calls: None,
+            tool_call_id: Some("call-1".to_string()),
+            tool_name: Some("send_discord_message".to_string()),
+            tool_arguments: Some("{\"channel_id\":\"chan-1\",\"message\":\"On it, give me a moment...\"}".to_string()),
+            tool_status: Some("done".to_string()),
+            weles_review: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            provider: None,
+            model: None,
+            api_transport: None,
+            response_id: None,
+            reasoning: None,
+            message_kind: AgentMessageKind::Normal,
+            compaction_strategy: None,
+            compaction_payload: None,
+            timestamp: 3,
+        },
+        AgentMessage {
+            id: "assistant-2".to_string(),
+            role: MessageRole::Assistant,
+            content: "I found the issue. The release notes need one more line.".to_string(),
+            tool_calls: None,
+            tool_call_id: None,
+            tool_name: None,
+            tool_arguments: None,
+            tool_status: None,
+            weles_review: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            provider: None,
+            model: None,
+            api_transport: None,
+            response_id: None,
+            reasoning: None,
+            message_kind: AgentMessageKind::Normal,
+            compaction_strategy: None,
+            compaction_payload: None,
+            timestamp: 4,
+        },
+    ];
+
+    assert!(
+        !gateway_turn_used_send_tool(&messages),
+        "a send tool before the latest assistant message should not suppress auto-send of that later message"
+    );
+    assert_eq!(
+        latest_gateway_turn_assistant_response(&messages).as_deref(),
+        Some("I found the issue. The release notes need one more line.")
+    );
+}
+
+#[test]
 fn daemon_gateway_loop_no_longer_polls_slack_discord_or_telegram() {
     let production_source = gateway_loop_production_source();
     for forbidden in [

--- a/crates/amux-daemon/src/agent/gateway_loop/tests/runtime.rs
+++ b/crates/amux-daemon/src/agent/gateway_loop/tests/runtime.rs
@@ -177,6 +177,104 @@ async fn gateway_health_snapshots_survive_gateway_restart() {
     fs::remove_dir_all(&root).expect("cleanup test root");
 }
 
+#[tokio::test]
+async fn gateway_auto_send_thread_response_emits_gateway_request_for_latest_assistant_message() {
+    let root = make_test_root("gateway-auto-send-thread-response");
+    let manager = SessionManager::new_test(&root).await;
+    let mut config = AgentConfig::default();
+    config.gateway.enabled = true;
+    let engine = AgentEngine::new_test(manager, config, &root).await;
+    engine.init_gateway().await;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    engine.set_gateway_ipc_sender(Some(tx)).await;
+
+    let incoming = gateway::IncomingMessage {
+        platform: "Discord".to_string(),
+        sender: "alice".to_string(),
+        content: "Can you check the release notes?".to_string(),
+        channel: "user:123456789".to_string(),
+        message_id: Some("discord-incoming-1".to_string()),
+        thread_context: None,
+    };
+
+    let thread_id = engine
+        .persist_gateway_fast_path_exchange(
+            "Discord:user:123456789",
+            &incoming,
+            "Initial reply",
+        )
+        .await
+        .expect("persist fast-path exchange");
+
+    {
+        let mut threads = engine.threads.write().await;
+        let thread = threads
+            .get_mut(&thread_id)
+            .expect("gateway thread should exist");
+        thread.messages.push(AgentMessage {
+            id: "assistant-latest".to_string(),
+            role: MessageRole::Assistant,
+            content: "Intermittent update from the agent".to_string(),
+            tool_calls: None,
+            tool_call_id: None,
+            tool_name: None,
+            tool_arguments: None,
+            tool_status: None,
+            weles_review: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            provider: None,
+            model: None,
+            api_transport: None,
+            response_id: None,
+            reasoning: None,
+            message_kind: AgentMessageKind::Normal,
+            compaction_strategy: None,
+            compaction_payload: None,
+            timestamp: now_millis(),
+        });
+        thread.updated_at = now_millis();
+    }
+    engine.persist_thread_by_id(&thread_id).await;
+
+    let helper_engine = engine.clone();
+    let helper_thread_id = thread_id.clone();
+    let send_task = tokio::spawn(async move {
+        helper_engine
+            .maybe_auto_send_gateway_thread_response(&helper_thread_id)
+            .await;
+    });
+
+    let request = match tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("gateway send request should be emitted")
+        .expect("gateway send request should exist")
+    {
+        amux_protocol::DaemonMessage::GatewaySendRequest { request } => request,
+        other => panic!("expected GatewaySendRequest, got {other:?}"),
+    };
+    assert_eq!(request.platform, "discord");
+    assert_eq!(request.channel_id, "user:123456789");
+    assert_eq!(request.content, "Intermittent update from the agent");
+
+    engine
+        .complete_gateway_send_result(amux_protocol::GatewaySendResult {
+            correlation_id: request.correlation_id.clone(),
+            platform: "discord".to_string(),
+            channel_id: "user:123456789".to_string(),
+            requested_channel_id: Some("user:123456789".to_string()),
+            delivery_id: Some("delivery-1".to_string()),
+            ok: true,
+            error: None,
+            completed_at_ms: now_millis(),
+        })
+        .await;
+
+    send_task.await.expect("auto-send task should join");
+    fs::remove_dir_all(&root).expect("cleanup test root");
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn daemon_respawns_gateway_process_when_enabled() {

--- a/crates/amux-daemon/src/agent/tool_executor/gateway_workspace.rs
+++ b/crates/amux-daemon/src/agent/tool_executor/gateway_workspace.rs
@@ -18,7 +18,7 @@ fn should_use_linked_whatsapp_transport(
     wa_link_state == "connected" || has_native_client || has_sidecar_process
 }
 
-async fn execute_gateway_message(
+pub(in crate::agent) async fn execute_gateway_message(
     tool_name: &str,
     args: &serde_json::Value,
     agent: &AgentEngine,

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -78,7 +78,7 @@ Minimal example:
 ```json
 {
   "name": "tamux-plugin-example",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "tamuxPlugin": {
     "entry": "dist/tamux-plugin.js",
     "format": "script"
@@ -105,7 +105,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.2.10",
+  version: "0.2.11",
   components: {
     ExamplePanel,
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamux",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamux",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@honcho-ai/sdk": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tamux",
   "private": true,
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Agentic terminal multiplexer with AI-native workflows",
   "homepage": "https://tamux.app",
   "author": {

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -137,7 +137,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>tamux - Terminal Multiplexer</p>
-                    <p>Version 0.2.10</p>
+                    <p>Version 0.2.11</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A cross-platform terminal multiplexer with workspaces, surfaces, pane management,
                         AI agent integration, snippet library, and session persistence.

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.2.10",
+        version: "0.2.11",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.2.10",
+        version: "0.2.11",
         assistantTools: [
             {
                 type: "function",

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamux",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "The Agent That Lives - daemon-first AI agent runtime",
   "license": "MIT",
   "homepage": "https://tamux.app",


### PR DESCRIPTION
This pull request introduces a cross-platform release automation workflow and improves the logic for auto-sending gateway thread responses in the agent. The main changes include a new GitHub Actions workflow for building and packaging releases for all major platforms, enhancements to the agent's logic for determining when to auto-send responses, and related code refactoring and tests.

**Release automation and packaging:**

* Added a comprehensive `.github/workflows/release.yml` GitHub Actions workflow to automate building, packaging, and releasing binaries and Electron apps for Linux, Windows, and macOS (both Intel and Apple Silicon). The workflow handles cross-compilation, frontend builds, artifact packaging, and GitHub Release creation.

**Agent gateway response logic improvements:**

* Refactored and improved the logic in `gateway_turn_used_send_tool` to more accurately determine if a send tool was used in the latest assistant turn, ensuring that auto-send is only suppressed when appropriate. This prevents earlier send tool calls from blocking auto-send for later assistant messages.
* Added new helper methods to `AgentEngine` (`gateway_message_target_for_thread`, `maybe_auto_send_gateway_thread_response`) to encapsulate and streamline the logic for determining when and how to auto-send gateway responses.
* Updated the agent's message handling flow to call `maybe_auto_send_gateway_thread_response` after message finalization and tool calls, ensuring that auto-send is triggered at the correct points. [[1]](diffhunk://#diff-d7ac17ac8fcf221f0555c6695004f97a9458b8210639e6e8be8e5f7db956e5a3R156-R158) [[2]](diffhunk://#diff-15926b01b685322537fdfdacc3217eb9609d3b6284b767bcef259b0e59715678R62-R64)
* Refactored internal gateway message sending to use the new helpers, simplifying the code and improving maintainability. [[1]](diffhunk://#diff-06db29035f097f3b405d82df7d239c31410e75d8b49fee00203e7e814d93822bL337-R380) [[2]](diffhunk://#diff-06db29035f097f3b405d82df7d239c31410e75d8b49fee00203e7e814d93822bL419-L420)

**Testing and versioning:**

* Added a new test to ensure that a send tool call before the latest assistant message does not suppress auto-send for a subsequent assistant message.
* Bumped the Cargo workspace version to 0.2.11.…gateway auto-send functionality