### PR TITLE
v0.2.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
-        working-directory: frontend
 
       - name: npm install + build
         run: npm ci && npm run build
@@ -115,7 +114,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
-        working-directory: frontend
 
       - name: npm install + build
         run: npm ci && npm run build
@@ -183,7 +181,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
-        working-directory: frontend
 
       - name: npm install + build
         run: npm ci && npm run build
@@ -252,7 +249,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
-        working-directory: frontend
 
       - name: npm install + build
         run: npm ci && npm run build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,7 +4376,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tamux-cli"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "base64",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-daemon"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-gateway"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "futures",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-mcp"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "futures",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-protocol"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-tui"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 license = "MIT"
 authors = ["tamux contributors"]

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -78,7 +78,7 @@ Minimal example:
 ```json
 {
   "name": "tamux-plugin-example",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "tamuxPlugin": {
     "entry": "dist/tamux-plugin.js",
     "format": "script"
@@ -105,7 +105,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.2.11",
+  version: "0.2.12",
   components: {
     ExamplePanel,
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamux",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamux",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@honcho-ai/sdk": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tamux",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Agentic terminal multiplexer with AI-native workflows",
   "homepage": "https://tamux.app",
   "author": {

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -137,7 +137,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>tamux - Terminal Multiplexer</p>
-                    <p>Version 0.2.11</p>
+                    <p>Version 0.2.12</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A cross-platform terminal multiplexer with workspaces, surfaces, pane management,
                         AI agent integration, snippet library, and session persistence.

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.2.11",
+        version: "0.2.12",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.2.11",
+        version: "0.2.12",
         assistantTools: [
             {
                 type: "function",

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamux",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "The Agent That Lives - daemon-first AI agent runtime",
   "license": "MIT",
   "homepage": "https://tamux.app",


### PR DESCRIPTION
This pull request updates the project version from 0.2.11 to 0.2.12 across all relevant files and documentation. Additionally, it removes the `working-directory: frontend` line from several steps in the GitHub Actions workflow configuration, potentially affecting how frontend build steps are executed.

Version bump to 0.2.12:

* Updated the version number from 0.2.11 to 0.2.12 in `Cargo.toml`, `frontend/package.json`, `frontend/package-lock.json`, `npm-package/package.json`, and in various documentation and source files referencing the version. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L13-R13) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9) [[4]](diffhunk://#diff-644eeeb901f63bf607ad522e934b62a9fa61c252872d74cc99e5f5e078b896d9L3-R3) [[5]](diffhunk://#diff-f86abbd74d48b08360106f915df7e32cb28bee57f154198f151a6274b05b1fd0L81-R81) [[6]](diffhunk://#diff-f86abbd74d48b08360106f915df7e32cb28bee57f154198f151a6274b05b1fd0L108-R108) [[7]](diffhunk://#diff-5b6294f09c85d1fb2b0f7e442e35e29853453863a2c77fd4dc401d74e565bd60L140-R140) [[8]](diffhunk://#diff-135b242f86713bdcda51a03ffbf25bcf337e319e09cd124db23718e503e4c026L87-R87) [[9]](diffhunk://#diff-717f73d06bc5e8fd3d41ab91a9280002adf096e8b12399d03fd54ce327f3350fL86-R86)

CI/CD workflow adjustments:

* Removed the `working-directory: frontend` line from multiple steps in `.github/workflows/release.yml`, which may change the context in which the frontend build commands are run. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L46) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L118) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L186) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L255)