### PR TITLE
Bump version to 0.2.16 and update dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
 env:
   NODE_VERSION: '22'
   RUST_VERSION: stable
+  TAMUX_LOG: error
+  AMUX_LOG: error
+  TAMUX_TUI_LOG: error
+  AMUX_GATEWAY_LOG: error
+  RUST_LOG: error
 
 jobs:
   # ================================================================
@@ -338,3 +343,42 @@ jobs:
             artifacts/**/*.deb
             artifacts/**/*.dmg
             SHA256SUMS.txt
+
+  # ================================================================
+  # Publish npm package via npm trusted publishing (OIDC)
+  # ================================================================
+  publish-npm:
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify package version matches tag
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./npm-package/package.json').version")
+          TAG_VERSION="${TAG_NAME#v}"
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "npm-package/package.json version $PACKAGE_VERSION does not match tag $TAG_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Dry-run npm pack
+        run: npm pack --dry-run
+        working-directory: npm-package
+
+      - name: Publish to npm
+        run: npm publish
+        working-directory: npm-package

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,7 +4376,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tamux-cli"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "base64",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-daemon"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-gateway"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "futures",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-mcp"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "futures",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-protocol"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-tui"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 license = "MIT"
 authors = ["tamux contributors"]

--- a/crates/amux-daemon/src/agent/agent_loop/send_message/loop_core.rs
+++ b/crates/amux-daemon/src/agent/agent_loop/send_message/loop_core.rs
@@ -248,6 +248,14 @@ impl<'a> SendMessageRunner<'a> {
                             if !content.is_empty() {
                                 self.assistant_output_visible = true;
                                 accumulated_content.push_str(&content);
+                                self.engine
+                                    .note_stream_progress(
+                                        &self.tid,
+                                        self.stream_generation,
+                                        StreamProgressKind::Content,
+                                        &content,
+                                    )
+                                    .await;
                                 let _ = self.engine.event_tx.send(AgentEvent::Delta {
                                     thread_id: self.tid.clone(),
                                     content,
@@ -255,6 +263,14 @@ impl<'a> SendMessageRunner<'a> {
                             }
                             if let Some(r) = reasoning {
                                 accumulated_reasoning.push_str(&r);
+                                self.engine
+                                    .note_stream_progress(
+                                        &self.tid,
+                                        self.stream_generation,
+                                        StreamProgressKind::Reasoning,
+                                        &r,
+                                    )
+                                    .await;
                                 let _ = self.engine.event_tx.send(AgentEvent::Reasoning {
                                     thread_id: self.tid.clone(),
                                     content: r,
@@ -291,10 +307,26 @@ impl<'a> SendMessageRunner<'a> {
                         }
                         CompletionChunk::TransportFallback { .. } => {}
                         chunk @ CompletionChunk::Done { .. } => {
+                            self.engine
+                                .note_stream_progress(
+                                    &self.tid,
+                                    self.stream_generation,
+                                    StreamProgressKind::Content,
+                                    &accumulated_content,
+                                )
+                                .await;
                             final_chunk = Some(chunk);
                             break;
                         }
                         chunk @ CompletionChunk::ToolCalls { .. } => {
+                            self.engine
+                                .note_stream_progress(
+                                    &self.tid,
+                                    self.stream_generation,
+                                    StreamProgressKind::ToolCalls,
+                                    &accumulated_reasoning,
+                                )
+                                .await;
                             final_chunk = Some(chunk);
                             break;
                         }

--- a/crates/amux-daemon/src/agent/engine.rs
+++ b/crates/amux-daemon/src/agent/engine.rs
@@ -38,6 +38,18 @@ pub struct StreamCancellationEntry {
     pub generation: u64,
     pub token: CancellationToken,
     pub retry_now: Arc<tokio::sync::Notify>,
+    pub started_at: u64,
+    pub last_progress_at: u64,
+    pub last_progress_kind: StreamProgressKind,
+    pub last_progress_excerpt: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamProgressKind {
+    Started,
+    Reasoning,
+    Content,
+    ToolCalls,
 }
 
 pub struct ThreadRepoWatcher {

--- a/crates/amux-daemon/src/agent/engine_runtime.rs
+++ b/crates/amux-daemon/src/agent/engine_runtime.rs
@@ -261,6 +261,7 @@ impl AgentEngine {
         let generation = self.stream_generation.fetch_add(1, Ordering::Relaxed);
         let token = CancellationToken::new();
         let retry_now = Arc::new(tokio::sync::Notify::new());
+        let now = now_millis();
         let mut streams = self.stream_cancellations.lock().await;
         if let Some(previous) = streams.insert(
             thread_id.to_string(),
@@ -268,6 +269,10 @@ impl AgentEngine {
                 generation,
                 token: token.clone(),
                 retry_now: retry_now.clone(),
+                started_at: now,
+                last_progress_at: now,
+                last_progress_kind: StreamProgressKind::Started,
+                last_progress_excerpt: String::new(),
             },
         ) {
             previous.token.cancel();
@@ -284,6 +289,25 @@ impl AgentEngine {
         if should_remove {
             streams.remove(thread_id);
         }
+    }
+
+    pub(super) async fn note_stream_progress(
+        &self,
+        thread_id: &str,
+        generation: u64,
+        kind: StreamProgressKind,
+        excerpt: &str,
+    ) {
+        let mut streams = self.stream_cancellations.lock().await;
+        let Some(entry) = streams.get_mut(thread_id) else {
+            return;
+        };
+        if entry.generation != generation {
+            return;
+        }
+        entry.last_progress_at = now_millis();
+        entry.last_progress_kind = kind;
+        entry.last_progress_excerpt = excerpt.chars().take(180).collect();
     }
 
     pub async fn stop_stream(&self, thread_id: &str) -> bool {

--- a/crates/amux-daemon/src/agent/messaging.rs
+++ b/crates/amux-daemon/src/agent/messaging.rs
@@ -5,6 +5,28 @@ use super::*;
 mod concierge;
 
 impl AgentEngine {
+    async fn prepare_internal_dm_thread(
+        &self,
+        sender: &str,
+        recipient: &str,
+        wrapped_content: &str,
+    ) -> String {
+        let dm_thread_id = internal_dm_thread_id(sender, recipient);
+        let _ = self
+            .get_or_create_thread_with_target(Some(&dm_thread_id), wrapped_content, Some(recipient))
+            .await;
+        self.set_thread_handoff_state(
+            &dm_thread_id,
+            initial_thread_handoff_state(
+                &dm_thread_id,
+                Some(canonical_agent_name(recipient)),
+                now_millis(),
+            ),
+        )
+        .await;
+        dm_thread_id
+    }
+
     pub async fn delete_thread_messages(
         &self,
         thread_id: &str,
@@ -490,8 +512,10 @@ impl AgentEngine {
         backend_override: Option<&str>,
         content: &str,
     ) -> Result<SendMessageOutcome> {
-        let dm_thread_id = internal_dm_thread_id(sender, recipient);
         let wrapped = wrap_internal_message(sender, recipient, content);
+        let dm_thread_id = self
+            .prepare_internal_dm_thread(sender, recipient, &wrapped)
+            .await;
         let outcome = Box::pin(self.send_message_inner(
             Some(&dm_thread_id),
             &wrapped,
@@ -568,8 +592,10 @@ impl AgentEngine {
         content: &str,
         preferred_session_hint: Option<&str>,
     ) -> Result<(String, String)> {
-        let dm_thread_id = internal_dm_thread_id(sender, recipient);
         let wrapped = wrap_internal_message(sender, recipient, content);
+        let dm_thread_id = self
+            .prepare_internal_dm_thread(sender, recipient, &wrapped)
+            .await;
         if is_concierge_target(recipient) {
             Box::pin(self.send_concierge_message_on_thread(
                 &dm_thread_id,

--- a/crates/amux-daemon/src/agent/stalled_turns/history_scan.rs
+++ b/crates/amux-daemon/src/agent/stalled_turns/history_scan.rs
@@ -1,22 +1,42 @@
 use super::analysis::classify_stalled_turn;
-use super::types::{ThreadStallObservation, TurnEvidence};
+use super::types::{StalledTurnClass, ThreadStallObservation, TurnEvidence};
 use super::*;
 
 impl AgentEngine {
     pub(super) async fn collect_stalled_turn_observations(&self) -> Vec<ThreadStallObservation> {
         let active_streams = {
             let streams = self.stream_cancellations.lock().await;
-            streams.keys().cloned().collect::<HashSet<_>>()
+            streams
+                .iter()
+                .map(|(thread_id, entry)| (thread_id.clone(), entry.clone()))
+                .collect::<Vec<_>>()
         };
+        let active_stream_ids = active_streams
+            .iter()
+            .map(|(thread_id, _)| thread_id.clone())
+            .collect::<HashSet<_>>();
         let threads = self.threads.read().await;
         let goal_runs = self.goal_runs.lock().await;
         let tasks = self.tasks.lock().await;
+        let now = now_millis();
 
-        threads
+        let mut observations = threads
             .values()
-            .filter(|thread| !active_streams.contains(&thread.id))
+            .filter(|thread| !active_stream_ids.contains(&thread.id))
             .filter_map(|thread| latest_stalled_turn_observation(thread, &tasks, &goal_runs))
-            .collect()
+            .collect::<Vec<_>>();
+
+        observations.extend(active_streams.into_iter().filter_map(|(thread_id, entry)| {
+            if now.saturating_sub(entry.last_progress_at) < super::runtime::INITIAL_GRACE_DELAY_MS
+                || matches!(entry.last_progress_kind, StreamProgressKind::Started)
+            {
+                return None;
+            }
+            let thread = threads.get(&thread_id)?;
+            idle_stream_stall_observation(thread, &tasks, &goal_runs, &entry)
+        }));
+
+        observations
     }
 }
 
@@ -63,6 +83,32 @@ fn latest_stalled_turn_observation(
         last_message_at: last_message.timestamp,
         last_assistant_message: last_message.content.clone(),
         class,
+        stream_progress_kind: None,
+        task_id: active_task_id_for_thread(thread.id.as_str(), tasks),
+        goal_run_id: goal_run_id_for_thread(thread.id.as_str(), goal_runs),
+    })
+}
+
+fn idle_stream_stall_observation(
+    thread: &AgentThread,
+    tasks: &VecDeque<AgentTask>,
+    goal_runs: &VecDeque<GoalRun>,
+    stream: &StreamCancellationEntry,
+) -> Option<ThreadStallObservation> {
+    Some(ThreadStallObservation {
+        thread_id: thread.id.clone(),
+        last_message_id: format!(
+            "stream:{}:{}:{:?}",
+            stream.generation, stream.last_progress_at, stream.last_progress_kind
+        ),
+        last_message_at: stream.last_progress_at,
+        last_assistant_message: if stream.last_progress_excerpt.trim().is_empty() {
+            "Stream went idle before completion.".to_string()
+        } else {
+            stream.last_progress_excerpt.clone()
+        },
+        class: StalledTurnClass::ActiveStreamIdle,
+        stream_progress_kind: Some(stream.last_progress_kind),
         task_id: active_task_id_for_thread(thread.id.as_str(), tasks),
         goal_run_id: goal_run_id_for_thread(thread.id.as_str(), goal_runs),
     })

--- a/crates/amux-daemon/src/agent/stalled_turns/recovery.rs
+++ b/crates/amux-daemon/src/agent/stalled_turns/recovery.rs
@@ -1,4 +1,5 @@
 use super::runtime::StalledTurnCandidate;
+use super::types::StalledTurnClass;
 use super::*;
 
 impl AgentEngine {
@@ -44,6 +45,37 @@ impl AgentEngine {
             thread.updated_at = now_millis();
         }
         self.persist_thread_by_id(&candidate.thread_id).await;
+
+        let responder_agent_id = self
+            .active_agent_id_for_thread(&candidate.thread_id)
+            .await
+            .unwrap_or_else(|| crate::agent::agent_identity::MAIN_AGENT_ID.to_string());
+        if crate::agent::agent_identity::canonical_agent_id(&responder_agent_id)
+            != crate::agent::agent_identity::WELES_AGENT_ID
+        {
+            let internal_message = stalled_turn_internal_dm_message(
+                candidate,
+                attempt,
+                &prior_user_message,
+                &responder_agent_id,
+            );
+            if let Err(error) = self
+                .send_internal_agent_message(
+                    crate::agent::agent_identity::WELES_AGENT_ID,
+                    &responder_agent_id,
+                    &internal_message,
+                    None,
+                )
+                .await
+            {
+                tracing::warn!(
+                    thread_id = %candidate.thread_id,
+                    recipient = %responder_agent_id,
+                    error = %error,
+                    "failed to send stalled-turn internal DM"
+                );
+            }
+        }
 
         self.emit_workflow_notice(
             &candidate.thread_id,
@@ -114,6 +146,20 @@ impl AgentEngine {
 }
 
 fn stalled_turn_system_message(candidate: &StalledTurnCandidate, attempt: u32) -> String {
+    if candidate.class == StalledTurnClass::ActiveStreamIdle {
+        return match attempt {
+            1 => "WELES stalled-turn recovery: Your stream went idle before completion. Resume the unfinished turn now.".to_string(),
+            2 => format!(
+                "WELES stalled-turn recovery: Your stream went idle after partial output (\"{}\"). Continue the unfinished turn now.",
+                candidate.last_message_excerpt
+            ),
+            _ => format!(
+                "WELES stalled-turn recovery: The stream kept stalling before completion. Resume immediately from this unfinished point: {}",
+                candidate.last_message_excerpt
+            ),
+        };
+    }
+
     match attempt {
         1 => "WELES stalled-turn recovery: Continue from your last unfinished action.".to_string(),
         2 => format!(
@@ -123,6 +169,29 @@ fn stalled_turn_system_message(candidate: &StalledTurnCandidate, attempt: u32) -
         _ => format!(
             "WELES stalled-turn recovery: Your previous turn stopped after promising work but before taking action. Resume immediately from this unfinished step: {}",
             candidate.last_message_excerpt
+        ),
+    }
+}
+
+fn stalled_turn_internal_dm_message(
+    candidate: &StalledTurnCandidate,
+    attempt: u32,
+    prior_user_message: &str,
+    responder_agent_id: &str,
+) -> String {
+    let responder_name = crate::agent::agent_identity::canonical_agent_name(responder_agent_id);
+    match candidate.class {
+        StalledTurnClass::ActiveStreamIdle => format!(
+            "WELES stalled-turn recovery for thread `{}`.\nAttempt {attempt}/3.\nYou are the active responder ({responder_name}). Your stream went idle before completion after partial output: \"{}\"\nResume the original operator request immediately: {}",
+            candidate.thread_id,
+            candidate.last_message_excerpt,
+            prior_user_message,
+        ),
+        _ => format!(
+            "WELES stalled-turn recovery for thread `{}`.\nAttempt {attempt}/3.\nYou are the active responder ({responder_name}). Your last unfinished message was: \"{}\"\nContinue the original operator request immediately: {}",
+            candidate.thread_id,
+            candidate.last_message_excerpt,
+            prior_user_message,
         ),
     }
 }

--- a/crates/amux-daemon/src/agent/stalled_turns/runtime.rs
+++ b/crates/amux-daemon/src/agent/stalled_turns/runtime.rs
@@ -1,7 +1,7 @@
 use super::types::{StalledTurnClass, ThreadStallObservation};
 use super::*;
 
-const INITIAL_GRACE_DELAY_MS: u64 = 30_000;
+pub(super) const INITIAL_GRACE_DELAY_MS: u64 = 30_000;
 const SECOND_RETRY_DELAY_MS: u64 = 60_000;
 const THIRD_RETRY_DELAY_MS: u64 = 120_000;
 
@@ -80,6 +80,7 @@ impl StalledTurnClass {
         match self {
             Self::PromiseWithoutAction => "promise_without_action",
             Self::PostToolResultNoFollowThrough => "post_tool_result_no_follow_through",
+            Self::ActiveStreamIdle => "active_stream_idle",
         }
     }
 }

--- a/crates/amux-daemon/src/agent/stalled_turns/tests.rs
+++ b/crates/amux-daemon/src/agent/stalled_turns/tests.rs
@@ -5,6 +5,10 @@ use crate::agent::types::{
     AgentConfig, AgentMessage, AgentTask, AgentThread, ApiTransport, MessageRole, TaskPriority,
     TaskStatus, ToolCall, ToolFunction,
 };
+use crate::agent::{
+    StreamProgressKind, ThreadHandoffState, ThreadResponderFrame, CONCIERGE_AGENT_ID,
+    CONCIERGE_AGENT_NAME, MAIN_AGENT_ID, MAIN_AGENT_NAME, WELES_AGENT_ID,
+};
 use crate::session_manager::SessionManager;
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -281,10 +285,11 @@ async fn collect_stalled_turn_observations_detects_promise_without_action() {
         observations[0].class,
         StalledTurnClass::PromiseWithoutAction
     );
+    assert_eq!(observations[0].stream_progress_kind, None);
 }
 
 #[tokio::test]
-async fn supervise_stalled_turns_retries_with_system_recovery_and_continue() {
+async fn supervise_stalled_turns_retries_with_internal_ping_and_continue() {
     let engine = build_test_engine("Recovered.").await;
     let now = super::now_millis();
     let thread_id = "thread-recovery";
@@ -356,6 +361,190 @@ async fn supervise_stalled_turns_retries_with_system_recovery_and_continue() {
         "stalled-turn retries should not append a synthetic user 'continue' message"
     );
     assert!(thread.messages.iter().any(|message| {
+        message.role == MessageRole::Assistant && message.content.contains("Recovered.")
+    }));
+    drop(threads);
+
+    let dm_thread_id = crate::agent::agent_identity::internal_dm_thread_id(WELES_AGENT_ID, MAIN_AGENT_ID);
+    let threads = engine.threads.read().await;
+    let dm_thread = threads.get(&dm_thread_id).expect("internal recovery DM should exist");
+    assert_eq!(dm_thread.agent_name.as_deref(), Some(MAIN_AGENT_NAME));
+    assert!(dm_thread.messages.iter().any(|message| {
+        message.role == MessageRole::Assistant && message.content.contains("Recovered.")
+    }));
+}
+
+#[tokio::test]
+async fn collect_stalled_turn_observations_detects_idle_active_reasoning_stream() {
+    let engine = build_test_engine("Acknowledged.").await;
+    let now = super::now_millis();
+    let thread_id = "thread-idle-stream";
+
+    {
+        let mut threads = engine.threads.write().await;
+        threads.insert(
+            thread_id.to_string(),
+            AgentThread {
+                id: thread_id.to_string(),
+                agent_name: Some(CONCIERGE_AGENT_NAME.to_string()),
+                title: "Idle stream".to_string(),
+                messages: vec![AgentMessage::user("Keep going", now.saturating_sub(61_000))],
+                pinned: false,
+                upstream_thread_id: None,
+                upstream_transport: None,
+                upstream_provider: None,
+                upstream_model: None,
+                upstream_assistant_id: None,
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                created_at: now,
+                updated_at: now,
+            },
+        );
+    }
+    engine
+        .set_thread_handoff_state(
+            thread_id,
+            ThreadHandoffState {
+                origin_agent_id: MAIN_AGENT_ID.to_string(),
+                active_agent_id: CONCIERGE_AGENT_ID.to_string(),
+                responder_stack: vec![
+                    ThreadResponderFrame {
+                        agent_id: MAIN_AGENT_ID.to_string(),
+                        agent_name: MAIN_AGENT_NAME.to_string(),
+                        entered_at: now.saturating_sub(61_000),
+                        entered_via_handoff_event_id: None,
+                        linked_thread_id: None,
+                    },
+                    ThreadResponderFrame {
+                        agent_id: CONCIERGE_AGENT_ID.to_string(),
+                        agent_name: CONCIERGE_AGENT_NAME.to_string(),
+                        entered_at: now.saturating_sub(60_000),
+                        entered_via_handoff_event_id: None,
+                        linked_thread_id: None,
+                    },
+                ],
+                events: Vec::new(),
+                pending_approval_id: None,
+            },
+        )
+        .await;
+
+    let (generation, _, _) = engine.begin_stream_cancellation(thread_id).await;
+    engine
+        .note_stream_progress(
+            thread_id,
+            generation,
+            StreamProgressKind::Reasoning,
+            "thinking through the next step",
+        )
+        .await;
+    {
+        let mut streams = engine.stream_cancellations.lock().await;
+        let entry = streams.get_mut(thread_id).expect("active stream entry should exist");
+        entry.last_progress_at = now.saturating_sub(31_000);
+    }
+
+    let observations = engine.collect_stalled_turn_observations().await;
+    assert_eq!(observations.len(), 1);
+    assert_eq!(observations[0].class, StalledTurnClass::ActiveStreamIdle);
+    assert_eq!(
+        observations[0].stream_progress_kind,
+        Some(StreamProgressKind::Reasoning)
+    );
+}
+
+#[tokio::test]
+async fn supervise_stalled_turns_recovers_idle_reasoning_stream_via_internal_dm() {
+    let engine = build_test_engine("Recovered.").await;
+    let now = super::now_millis();
+    let thread_id = "thread-idle-stream-recovery";
+
+    {
+        let mut threads = engine.threads.write().await;
+        threads.insert(
+            thread_id.to_string(),
+            AgentThread {
+                id: thread_id.to_string(),
+                agent_name: Some(CONCIERGE_AGENT_NAME.to_string()),
+                title: "Idle stream recovery".to_string(),
+                messages: vec![AgentMessage::user("Continue the unfinished job", now.saturating_sub(61_000))],
+                pinned: false,
+                upstream_thread_id: None,
+                upstream_transport: None,
+                upstream_provider: None,
+                upstream_model: None,
+                upstream_assistant_id: None,
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                created_at: now,
+                updated_at: now,
+            },
+        );
+    }
+    engine
+        .set_thread_handoff_state(
+            thread_id,
+            ThreadHandoffState {
+                origin_agent_id: MAIN_AGENT_ID.to_string(),
+                active_agent_id: CONCIERGE_AGENT_ID.to_string(),
+                responder_stack: vec![
+                    ThreadResponderFrame {
+                        agent_id: MAIN_AGENT_ID.to_string(),
+                        agent_name: MAIN_AGENT_NAME.to_string(),
+                        entered_at: now.saturating_sub(61_000),
+                        entered_via_handoff_event_id: None,
+                        linked_thread_id: None,
+                    },
+                    ThreadResponderFrame {
+                        agent_id: CONCIERGE_AGENT_ID.to_string(),
+                        agent_name: CONCIERGE_AGENT_NAME.to_string(),
+                        entered_at: now.saturating_sub(60_000),
+                        entered_via_handoff_event_id: None,
+                        linked_thread_id: None,
+                    },
+                ],
+                events: Vec::new(),
+                pending_approval_id: None,
+            },
+        )
+        .await;
+
+    let (generation, _, _) = engine.begin_stream_cancellation(thread_id).await;
+    engine
+        .note_stream_progress(
+            thread_id,
+            generation,
+            StreamProgressKind::Reasoning,
+            "thinking through the next step",
+        )
+        .await;
+    {
+        let mut streams = engine.stream_cancellations.lock().await;
+        let entry = streams.get_mut(thread_id).expect("active stream entry should exist");
+        entry.last_progress_at = now.saturating_sub(31_000);
+    }
+
+    engine
+        .supervise_stalled_turns()
+        .await
+        .expect("idle active stream should recover");
+
+    let threads = engine.threads.read().await;
+    let thread = threads.get(thread_id).expect("thread should exist");
+    assert!(thread.messages.iter().any(|message| {
+        message.role == MessageRole::System
+            && message.content.contains("stream went idle before completion")
+    }));
+    assert!(thread.messages.iter().any(|message| {
+        message.role == MessageRole::Assistant && message.content.contains("Recovered.")
+    }));
+
+    let dm_thread_id =
+        crate::agent::agent_identity::internal_dm_thread_id(WELES_AGENT_ID, CONCIERGE_AGENT_ID);
+    let dm_thread = threads.get(&dm_thread_id).expect("recovery DM should exist");
+    assert_eq!(dm_thread.agent_name.as_deref(), Some(CONCIERGE_AGENT_NAME));
+    assert!(dm_thread.messages.iter().any(|message| {
         message.role == MessageRole::Assistant && message.content.contains("Recovered.")
     }));
 }

--- a/crates/amux-daemon/src/agent/stalled_turns/types.rs
+++ b/crates/amux-daemon/src/agent/stalled_turns/types.rs
@@ -1,7 +1,10 @@
+use super::StreamProgressKind;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum StalledTurnClass {
     PromiseWithoutAction,
     PostToolResultNoFollowThrough,
+    ActiveStreamIdle,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,6 +24,7 @@ pub(super) struct ThreadStallObservation {
     pub(super) last_message_at: u64,
     pub(super) last_assistant_message: String,
     pub(super) class: StalledTurnClass,
+    pub(super) stream_progress_kind: Option<StreamProgressKind>,
     pub(super) task_id: Option<String>,
     pub(super) goal_run_id: Option<String>,
 }

--- a/crates/amux-tui/src/main.rs
+++ b/crates/amux-tui/src/main.rs
@@ -27,6 +27,7 @@ use crossterm::{
 };
 use ratatui::prelude::*;
 use tokio::sync::mpsc as tokio_mpsc;
+use tracing_subscriber::EnvFilter;
 
 use crate::app::TuiModel;
 use crate::client::DaemonClient;
@@ -37,8 +38,14 @@ fn main() -> Result<()> {
     let log_path = log_writer.current_path()?;
     let (log_writer, _log_guard) = tracing_appender::non_blocking(log_writer);
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
+        .with_env_filter(
+            EnvFilter::try_from_env("TAMUX_TUI_LOG")
+                .or_else(|_| EnvFilter::try_from_env("TAMUX_LOG"))
+                .or_else(|_| EnvFilter::try_from_env("AMUX_LOG"))
+                .unwrap_or_else(|_| EnvFilter::new("info")),
+        )
         .with_writer(log_writer)
+        .with_ansi(false)
         .init();
     tracing::info!(path = %log_path.display(), "tui log file initialized");
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -78,7 +78,7 @@ Minimal example:
 ```json
 {
   "name": "tamux-plugin-example",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "tamuxPlugin": {
     "entry": "dist/tamux-plugin.js",
     "format": "script"
@@ -105,7 +105,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.2.15",
+  version: "0.2.16",
   components: {
     ExamplePanel,
   },

--- a/frontend/electron/main.cjs
+++ b/frontend/electron/main.cjs
@@ -53,6 +53,7 @@ const { getAvailableShells, getSystemFonts, getSystemMonitorSnapshot } = require
 const { createTerminalBridgeRuntime } = require('./main/terminal-bridge-runtime.cjs');
 const { createWhatsAppRuntime } = require('./main/whatsapp-runtime.cjs');
 const { createWindowRuntime } = require('./main/window-runtime.cjs');
+const { createChildLogEnv } = require('./main/log-env.cjs');
 
 const DAEMON_NAME = 'tamux-daemon';
 const CLI_NAME = 'tamux';
@@ -66,10 +67,15 @@ let mainWindow = null;
 // Module-level reference to sendAgentCommand (set during registerIpcHandlers)
 let sendAgentCommandFn = null;
 
+function getChildProcessEnv() {
+    return createChildLogEnv(process.env, { isPackaged: app.isPackaged });
+}
+
 const terminalBridgeRuntime = createTerminalBridgeRuntime({
     cloneSessionPrefix: CLONE_SESSION_PREFIX,
     fs,
     getCliPath,
+    getChildProcessEnv,
     getMainWindow: () => mainWindow,
     logToFile,
     maxReattachHistoryBytes: MAX_REATTACH_HISTORY_BYTES,
@@ -108,6 +114,7 @@ async function convertWhatsAppQrToDataUrl(qrPayload) {
 const whatsAppRuntime = createWhatsAppRuntime({
     electronDir: __dirname,
     fs,
+    getChildProcessEnv,
     getMainWindow: () => mainWindow,
     logToFile,
     path,
@@ -119,6 +126,7 @@ const whatsAppRuntime = createWhatsAppRuntime({
 const agentDbBridgeRuntime = createAgentDbBridgeRuntime({
     fs,
     getDaemonPath,
+    getChildProcessEnv,
     getMainWindow: () => mainWindow,
     logToFile,
     pendingHandlerMatchesResponseType,
@@ -369,7 +377,7 @@ async function spawnDaemon() {
         return false;
     }
 
-    const daemonEnv = { ...process.env };
+    const daemonEnv = getChildProcessEnv();
     if (!daemonEnv.TAMUX_WHATSAPP_NODE_BIN || !String(daemonEnv.TAMUX_WHATSAPP_NODE_BIN).trim()) {
         daemonEnv.TAMUX_WHATSAPP_NODE_BIN = process.execPath;
     }

--- a/frontend/electron/main/agent-db-bridge-runtime.cjs
+++ b/frontend/electron/main/agent-db-bridge-runtime.cjs
@@ -2,6 +2,7 @@ function createAgentDbBridgeRuntime(options) {
     const {
         fs,
         getDaemonPath,
+        getChildProcessEnv = () => process.env,
         getMainWindow,
         logToFile,
         pendingHandlerMatchesResponseType,
@@ -59,6 +60,7 @@ function createAgentDbBridgeRuntime(options) {
 
         const bridgeProcess = spawn(cliPath, ['agent-bridge'], {
             cwd: require('path').dirname(cliPath),
+            env: getChildProcessEnv(),
             windowsHide: true,
             stdio: ['pipe', 'pipe', 'pipe'],
         });
@@ -216,6 +218,7 @@ function createAgentDbBridgeRuntime(options) {
 
         const bridgeProcess = spawn(cliPath, ['db-bridge'], {
             cwd: require('path').dirname(cliPath),
+            env: getChildProcessEnv(),
             windowsHide: true,
             stdio: ['pipe', 'pipe', 'pipe'],
         });

--- a/frontend/electron/main/log-env.cjs
+++ b/frontend/electron/main/log-env.cjs
@@ -1,0 +1,24 @@
+const ERROR_ONLY_LOG_ENV = Object.freeze({
+    TAMUX_LOG: 'error',
+    AMUX_LOG: 'error',
+    TAMUX_TUI_LOG: 'error',
+    AMUX_GATEWAY_LOG: 'error',
+    RUST_LOG: 'error',
+});
+
+function createChildLogEnv(baseEnv = process.env, options = {}) {
+    const env = { ...baseEnv };
+    if (!options.isPackaged) {
+        return env;
+    }
+
+    return {
+        ...env,
+        ...ERROR_ONLY_LOG_ENV,
+    };
+}
+
+module.exports = {
+    ERROR_ONLY_LOG_ENV,
+    createChildLogEnv,
+};

--- a/frontend/electron/main/terminal-bridge-runtime.cjs
+++ b/frontend/electron/main/terminal-bridge-runtime.cjs
@@ -3,6 +3,7 @@ function createTerminalBridgeRuntime(options) {
         cloneSessionPrefix,
         fs,
         getCliPath,
+        getChildProcessEnv = () => process.env,
         getMainWindow,
         logToFile,
         maxReattachHistoryBytes,
@@ -277,6 +278,7 @@ function createTerminalBridgeRuntime(options) {
             const result = await new Promise((resolve, reject) => {
                 const child = spawn(cliPath, args, {
                     cwd: path.dirname(cliPath),
+                    env: getChildProcessEnv(),
                     windowsHide: true,
                     stdio: ['ignore', 'pipe', 'pipe'],
                 });
@@ -363,6 +365,7 @@ function createTerminalBridgeRuntime(options) {
 
         const bridgeProcess = spawn(cliPath, args, {
             cwd: path.dirname(cliPath),
+            env: getChildProcessEnv(),
             windowsHide: true,
             stdio: ['pipe', 'pipe', 'pipe'],
         });

--- a/frontend/electron/main/whatsapp-runtime.cjs
+++ b/frontend/electron/main/whatsapp-runtime.cjs
@@ -2,6 +2,7 @@ function createWhatsAppRuntime(options) {
     const {
         electronDir,
         fs,
+        getChildProcessEnv = () => processRef.env,
         getMainWindow,
         logToFile,
         path,
@@ -89,7 +90,7 @@ function createWhatsAppRuntime(options) {
         logToFile('info', 'starting WhatsApp bridge sidecar');
         whatsappProcess = spawn(processRef.execPath, [bridgePath], {
             stdio: ['pipe', 'pipe', 'pipe'],
-            env: { ...processRef.env, ELECTRON_RUN_AS_NODE: '1' },
+            env: { ...getChildProcessEnv(), ELECTRON_RUN_AS_NODE: '1' },
         });
 
         let buffer = '';

--- a/frontend/electron/production-log-env.test.cjs
+++ b/frontend/electron/production-log-env.test.cjs
@@ -1,0 +1,71 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { createChildLogEnv } = require("./main/log-env.cjs");
+
+const repoRoot = path.join(__dirname, "..");
+
+test("packaged runtime forces rust log env to error", () => {
+  const env = createChildLogEnv(
+    {
+      TAMUX_LOG: "debug",
+      AMUX_LOG: "trace",
+      TAMUX_TUI_LOG: "info",
+      AMUX_GATEWAY_LOG: "warn",
+      RUST_LOG: "debug",
+      KEEP_ME: "yes",
+    },
+    { isPackaged: true },
+  );
+
+  assert.equal(env.TAMUX_LOG, "error");
+  assert.equal(env.AMUX_LOG, "error");
+  assert.equal(env.TAMUX_TUI_LOG, "error");
+  assert.equal(env.AMUX_GATEWAY_LOG, "error");
+  assert.equal(env.RUST_LOG, "error");
+  assert.equal(env.KEEP_ME, "yes");
+});
+
+test("development runtime preserves existing rust log env", () => {
+  const env = createChildLogEnv(
+    {
+      TAMUX_LOG: "debug",
+      AMUX_LOG: "trace",
+      RUST_LOG: "info",
+    },
+    { isPackaged: false },
+  );
+
+  assert.equal(env.TAMUX_LOG, "debug");
+  assert.equal(env.AMUX_LOG, "trace");
+  assert.equal(env.RUST_LOG, "info");
+});
+
+test("release workflow exports error-only log env", () => {
+  const releaseWorkflow = fs.readFileSync(path.join(repoRoot, "../.github/workflows/release.yml"), "utf8");
+
+  assert.match(releaseWorkflow, /TAMUX_LOG:\s*['"]?error['"]?/);
+  assert.match(releaseWorkflow, /AMUX_LOG:\s*['"]?error['"]?/);
+  assert.match(releaseWorkflow, /TAMUX_TUI_LOG:\s*['"]?error['"]?/);
+  assert.match(releaseWorkflow, /AMUX_GATEWAY_LOG:\s*['"]?error['"]?/);
+  assert.match(releaseWorkflow, /RUST_LOG:\s*['"]?error['"]?/);
+});
+
+test("release scripts export error-only log env", () => {
+  const scriptPaths = [
+    path.join(repoRoot, "../scripts/build-production-releases.sh"),
+    path.join(repoRoot, "../scripts/build-release.sh"),
+    path.join(repoRoot, "../scripts/build-release-wsl.sh"),
+    path.join(repoRoot, "../scripts/build-release.ps1"),
+    path.join(repoRoot, "../scripts/build-release.bat"),
+  ];
+
+  for (const scriptPath of scriptPaths) {
+    const source = fs.readFileSync(scriptPath, "utf8");
+    assert.match(source, /TAMUX_LOG/);
+    assert.match(source, /AMUX_LOG/);
+    assert.match(source, /error/);
+  }
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamux",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamux",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@honcho-ai/sdk": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tamux",
   "private": true,
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Agentic terminal multiplexer with AI-native workflows",
   "homepage": "https://tamux.app",
   "author": {

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -137,7 +137,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>tamux - Terminal Multiplexer</p>
-                    <p>Version 0.2.15</p>
+                    <p>Version 0.2.16</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A cross-platform terminal multiplexer with workspaces, surfaces, pane management,
                         AI agent integration, snippet library, and session persistence.

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.2.15",
+        version: "0.2.16",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.2.15",
+        version: "0.2.16",
         assistantTools: [
             {
                 type: "function",

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamux",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "The Agent That Lives - daemon-first AI agent runtime",
   "license": "MIT",
   "homepage": "https://tamux.app",

--- a/scripts/build-production-releases.sh
+++ b/scripts/build-production-releases.sh
@@ -5,6 +5,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 DIST_DIR="$PROJECT_ROOT/dist-release"
 
+export TAMUX_LOG=error
+export AMUX_LOG=error
+export TAMUX_TUI_LOG=error
+export AMUX_GATEWAY_LOG=error
+export RUST_LOG=error
+
 RUN_NATIVE=1
 RUN_WINDOWS=1
 SIGN=0

--- a/scripts/build-release-wsl.sh
+++ b/scripts/build-release-wsl.sh
@@ -26,6 +26,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUT_DIR="$PROJECT_ROOT/dist-release/windows"
 TARGET="x86_64-pc-windows-gnu"
+
+export TAMUX_LOG=error
+export AMUX_LOG=error
+export TAMUX_TUI_LOG=error
+export AMUX_GATEWAY_LOG=error
+export RUST_LOG=error
+
 APP_VERSION="$(sed -nE 's/^[[:space:]]*"version":[[:space:]]*"([^"]+)".*/\1/p' "$PROJECT_ROOT/frontend/package.json" | head -1)"
 if [[ -z "$APP_VERSION" ]]; then
     APP_VERSION="0.0.0"

--- a/scripts/build-release.bat
+++ b/scripts/build-release.bat
@@ -19,6 +19,11 @@ if "%~1"=="--sign" set SIGN=1
 
 set PROJECT_ROOT=%~dp0..
 set OUT_DIR=%PROJECT_ROOT%\dist-release
+set TAMUX_LOG=error
+set AMUX_LOG=error
+set TAMUX_TUI_LOG=error
+set AMUX_GATEWAY_LOG=error
+set RUST_LOG=error
 
 echo.
 echo ============================================================

--- a/scripts/build-release.ps1
+++ b/scripts/build-release.ps1
@@ -69,6 +69,12 @@ $ProjectRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 $OutDir = Join-Path $ProjectRoot "dist-release"
 $FrontendDir = Join-Path $ProjectRoot "frontend"
 
+$env:TAMUX_LOG = "error"
+$env:AMUX_LOG = "error"
+$env:TAMUX_TUI_LOG = "error"
+$env:AMUX_GATEWAY_LOG = "error"
+$env:RUST_LOG = "error"
+
 # ─────────────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────────────

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -15,6 +15,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+export TAMUX_LOG=error
+export AMUX_LOG=error
+export TAMUX_TUI_LOG=error
+export AMUX_GATEWAY_LOG=error
+export RUST_LOG=error
+
 SIGN=0
 SKIP_RUST=0
 SKIP_FRONTEND=0


### PR DESCRIPTION
- Updated version numbers in Cargo.lock, Cargo.toml, and various frontend files to 0.2.16.
- Enhanced SendMessageRunner to track stream progress with new note_stream_progress method.
- Introduced StreamProgressKind enum to categorize stream progress types.
- Implemented logic to collect stalled turn observations, including detection of idle active streams.
- Added internal direct messaging for stalled turn recovery.
- Updated logging environment variables to error level for production builds.
- Improved tests for stalled turn observations and recovery mechanisms.