### PR TITLE
feat: update version to 0.4.1 across all relevant files and add proto…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
 
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v3
+
       - name: Install Linux build dependencies
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
 
@@ -100,6 +103,9 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           targets: aarch64-unknown-linux-gnu
 
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v3
+
       - name: Install cross
         run: cargo install cross --locked --version 0.2.5
 
@@ -142,6 +148,9 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v3
 
       - name: Rust build (Windows native)
         shell: pwsh
@@ -220,6 +229,9 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           targets: x86_64-apple-darwin
 
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v3
+
       - name: Rust build
         run: cargo build --release --target x86_64-apple-darwin
 
@@ -287,6 +299,9 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: aarch64-apple-darwin
+
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v3
 
       - name: Rust build
         run: cargo build --release --target aarch64-apple-darwin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6844,7 +6844,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tamux-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-daemon"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -6933,7 +6933,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-gateway"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -6952,7 +6952,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -6971,7 +6971,7 @@ dependencies = [
 
 [[package]]
 name = "tamux-protocol"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -6989,11 +6989,11 @@ dependencies = [
 
 [[package]]
 name = "tamux-shared"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tamux-tui"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 authors = ["tamux contributors"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "apt-get update",
+    "apt-get install --assume-yes protobuf-compiler",
+]

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -78,7 +78,7 @@ Minimal example:
 ```json
 {
   "name": "tamux-plugin-example",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "tamuxPlugin": {
     "entry": "dist/tamux-plugin.js",
     "format": "script"
@@ -105,7 +105,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.4.0",
+  version: "0.4.1",
   components: {
     ExamplePanel,
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamux",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamux",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@honcho-ai/sdk": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tamux",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Agentic terminal multiplexer with AI-native workflows",
   "homepage": "https://tamux.app",
   "author": {

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -137,7 +137,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>tamux - Terminal Multiplexer</p>
-                    <p>Version 0.4.0</p>
+                    <p>Version 0.4.1</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A cross-platform terminal multiplexer with workspaces, surfaces, pane management,
                         AI agent integration, snippet library, and session persistence.

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.4.0",
+        version: "0.4.1",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.4.0",
+        version: "0.4.1",
         assistantTools: [
             {
                 type: "function",

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamux",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The Agent That Lives - daemon-first AI agent runtime",
   "license": "MIT",
   "homepage": "https://tamux.app",


### PR DESCRIPTION
This pull request updates the project to version 0.4.1 and ensures that the build process for all platforms includes the `protoc` compiler, which is required for working with Protocol Buffers. The changes also update documentation and plugin files to reflect the new version, and add necessary pre-build steps for cross-compiling to `aarch64-unknown-linux-gnu`.

**Build process improvements:**

* Added a step to set up `protoc` using `arduino/setup-protoc@v3` in all relevant jobs in `.github/workflows/release.yml` to ensure Protocol Buffers support during CI builds. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R32-R34) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R106-R108) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R152-R154) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R232-R234) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R303-R305)
* Updated `Cross.toml` to install `protobuf-compiler` as a pre-build step for the `aarch64-unknown-linux-gnu` target, improving cross-compilation support.

**Version bump to 0.4.1:**

* Bumped version from 0.4.0 to 0.4.1 across `Cargo.toml`, `frontend/package.json`, `frontend/package-lock.json`, `npm-package/package.json`, documentation, and plugin registration files to maintain consistency and reflect the new release. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L14-R14) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9) [[4]](diffhunk://#diff-f86abbd74d48b08360106f915df7e32cb28bee57f154198f151a6274b05b1fd0L81-R81) [[5]](diffhunk://#diff-f86abbd74d48b08360106f915df7e32cb28bee57f154198f151a6274b05b1fd0L108-R108) [[6]](diffhunk://#diff-5b6294f09c85d1fb2b0f7e442e35e29853453863a2c77fd4dc401d74e565bd60L140-R140) [[7]](diffhunk://#diff-135b242f86713bdcda51a03ffbf25bcf337e319e09cd124db23718e503e4c026L87-R87) [[8]](diffhunk://#diff-717f73d06bc5e8fd3d41ab91a9280002adf096e8b12399d03fd54ce327f3350fL86-R86) [[9]](diffhunk://#diff-644eeeb901f63bf607ad522e934b62a9fa61c252872d74cc99e5f5e078b896d9L3-R3)…c setup in release workflow