### PR TITLE
fix: support GitHub Copilot browser auth in setup wizard

### DIFF
--- a/crates/amux-cli/src/client/agent_bridge/commands.rs
+++ b/crates/amux-cli/src/client/agent_bridge/commands.rs
@@ -295,12 +295,14 @@ where
             provider_id,
             api_key,
             base_url,
+            auth_source,
         } => {
             framed
                 .send(ClientMessage::AgentLoginProvider {
                     provider_id,
                     api_key,
                     base_url,
+                    auth_source,
                 })
                 .await?;
         }

--- a/crates/amux-cli/src/client/agent_protocol.rs
+++ b/crates/amux-cli/src/client/agent_protocol.rs
@@ -159,6 +159,8 @@ pub(super) enum AgentBridgeCommand {
         api_key: String,
         #[serde(default)]
         base_url: String,
+        #[serde(default)]
+        auth_source: Option<String>,
     },
     LogoutProvider {
         provider_id: String,

--- a/crates/amux-cli/src/setup_wizard/flow.rs
+++ b/crates/amux-cli/src/setup_wizard/flow.rs
@@ -179,6 +179,93 @@ async fn configure_api_key(
     Ok(api_key)
 }
 
+async fn persist_provider_auth_source(
+    framed: &mut Framed<impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin, AmuxCodec>,
+    provider_id: &str,
+    auth_source: &str,
+) -> Result<()> {
+    let value_json = serde_json::to_string(auth_source).unwrap_or_default();
+    set_config_item(
+        framed,
+        format!("/providers/{provider_id}/auth_source"),
+        value_json.clone(),
+    )
+    .await
+    .with_context(|| format!("Failed to set auth_source for {provider_id}"))?;
+    set_config_item(framed, "/auth_source", value_json)
+        .await
+        .context("Failed to set active auth_source")?;
+    Ok(())
+}
+
+async fn configure_provider_auth(
+    framed: &mut Framed<impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin, AmuxCodec>,
+    provider: &ProviderSelection,
+    selected_provider: &ProviderAuthState,
+) -> Result<(String, String)> {
+    if provider.auth_source == "github_copilot" {
+        let options = if selected_provider.authenticated {
+            vec![
+                ("Keep existing browser login", "github_copilot_keep"),
+                ("Use browser login", "github_copilot"),
+                ("Use API token instead", "api_key"),
+            ]
+        } else {
+            vec![
+                ("Use browser login", "github_copilot"),
+                ("Use API token instead", "api_key"),
+            ]
+        };
+        let choice = select_list(
+            "How should GitHub Copilot authenticate?",
+            &options,
+            false,
+            0,
+        )?
+        .expect("provider auth selection is required");
+        let selected_auth_source = options[choice].1;
+
+        if selected_auth_source == "github_copilot_keep" {
+            persist_provider_auth_source(framed, &provider.provider_id, "github_copilot").await?;
+            println!("Keeping existing GitHub Copilot browser login.");
+            return Ok(("(existing)".to_string(), "github_copilot".to_string()));
+        }
+
+        if selected_auth_source == "github_copilot" {
+            persist_provider_auth_source(framed, &provider.provider_id, "github_copilot").await?;
+            let (success, message) = login_provider_on_stream(
+                framed,
+                &provider.provider_id,
+                "",
+                &provider.base_url,
+                Some("github_copilot"),
+            )
+            .await?;
+            if success {
+                if let Some(message) = message {
+                    println!("{message}.");
+                }
+                println!(
+                    "If the browser flow is still in progress, complete it and rerun `tamux setup` if validation fails."
+                );
+                return Ok((String::new(), "github_copilot".to_string()));
+            }
+            anyhow::bail!(
+                "{}",
+                message.unwrap_or_else(|| "GitHub Copilot login failed".to_string())
+            );
+        }
+
+        let api_key = configure_api_key(framed, provider, selected_provider).await?;
+        persist_provider_auth_source(framed, &provider.provider_id, "api_key").await?;
+        return Ok((api_key, "api_key".to_string()));
+    }
+
+    let api_key = configure_api_key(framed, provider, selected_provider).await?;
+    persist_provider_auth_source(framed, &provider.provider_id, &provider.auth_source).await?;
+    Ok((api_key, provider.auth_source.clone()))
+}
+
 async fn fetch_selected_provider_state(
     framed: &mut Framed<impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin, AmuxCodec>,
     provider_id: &str,
@@ -402,7 +489,8 @@ pub async fn run_setup_wizard() -> Result<PostSetupAction> {
     let selected_provider =
         fetch_selected_provider_state(&mut framed, &provider.provider_id).await?;
     println!();
-    let api_key_saved = configure_api_key(&mut framed, &provider, &selected_provider).await?;
+    let (api_key_saved, selected_auth_source) =
+        configure_provider_auth(&mut framed, &provider, &selected_provider).await?;
     println!();
 
     set_config_item(
@@ -428,7 +516,7 @@ pub async fn run_setup_wizard() -> Result<PostSetupAction> {
     if !is_local_provider(&provider.provider_id) && !api_key_saved.is_empty() {
         println!();
         println!("Testing connection to {}...", provider.provider_name);
-        match validate_provider_on_stream(&mut framed, &provider.provider_id, &provider.auth_source)
+        match validate_provider_on_stream(&mut framed, &provider.provider_id, &selected_auth_source)
             .await
         {
             Ok(true) => println!("{}", "Connection successful!".with(style::Color::Green)),

--- a/crates/amux-cli/src/setup_wizard/ipc.rs
+++ b/crates/amux-cli/src/setup_wizard/ipc.rs
@@ -83,6 +83,46 @@ pub(super) fn parse_provider_validation_terminal_response(
     }
 }
 
+pub(super) fn parse_provider_login_terminal_response(
+    msg: DaemonMessage,
+) -> Option<Result<(bool, Option<String>)>> {
+    match msg {
+        DaemonMessage::AgentProviderLoginResult {
+            success, message, ..
+        } => Some(Ok((success, message))),
+        DaemonMessage::Error { message } | DaemonMessage::AgentError { message } => {
+            Some(Err(anyhow::anyhow!(message)))
+        }
+        _ => None,
+    }
+}
+
+pub(super) async fn login_provider_on_stream(
+    framed: &mut Framed<impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin, AmuxCodec>,
+    provider_id: &str,
+    api_key: &str,
+    base_url: &str,
+    auth_source: Option<&str>,
+) -> Result<(bool, Option<String>)> {
+    wizard_send(
+        framed,
+        ClientMessage::AgentLoginProvider {
+            provider_id: provider_id.to_string(),
+            api_key: api_key.to_string(),
+            base_url: base_url.to_string(),
+            auth_source: auth_source.map(str::to_string),
+        },
+    )
+    .await?;
+
+    loop {
+        let msg = wizard_recv(framed).await?;
+        if let Some(result) = parse_provider_login_terminal_response(msg) {
+            return result;
+        }
+    }
+}
+
 pub(super) async fn validate_provider_on_stream(
     framed: &mut Framed<impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin, AmuxCodec>,
     provider_id: &str,

--- a/crates/amux-cli/src/setup_wizard/tests.rs
+++ b/crates/amux-cli/src/setup_wizard/tests.rs
@@ -346,6 +346,38 @@ fn config_set_response_completes_on_operation_acceptance() {
 }
 
 #[test]
+fn provider_login_terminal_response_extracts_success_payload() {
+    let response = parse_provider_login_terminal_response(DaemonMessage::AgentProviderLoginResult {
+        provider_id: "github-copilot".to_string(),
+        success: true,
+        message: Some("Started GitHub Copilot browser login".to_string()),
+    })
+    .expect("terminal response")
+    .expect("successful parse");
+
+    assert_eq!(
+        response,
+        (true, Some("Started GitHub Copilot browser login".to_string()))
+    );
+}
+
+#[test]
+fn provider_login_terminal_response_extracts_error_payload() {
+    let response = parse_provider_login_terminal_response(DaemonMessage::AgentProviderLoginResult {
+        provider_id: "github-copilot".to_string(),
+        success: false,
+        message: Some("GitHub CLI login flow failed".to_string()),
+    })
+    .expect("terminal response")
+    .expect("successful parse");
+
+    assert_eq!(
+        response,
+        (false, Some("GitHub CLI login flow failed".to_string()))
+    );
+}
+
+#[test]
 fn setup_probe_marks_ready_when_provider_is_persisted() {
     assert_eq!(
         setup_probe_from_config_json(r#"{"provider":"openai"}"#),

--- a/crates/amux-daemon/src/server/dispatch_part6.rs
+++ b/crates/amux-daemon/src/server/dispatch_part6.rs
@@ -634,7 +634,51 @@ if matches!(
                     provider_id,
                     api_key,
                     base_url,
+                    auth_source,
                 } => {
+                    if provider_id == amux_shared::providers::PROVIDER_ID_GITHUB_COPILOT
+                        && matches!(auth_source.as_deref(), Some("github_copilot"))
+                    {
+                        match crate::agent::copilot_auth::begin_github_copilot_auth_flow() {
+                            Ok(result) => {
+                                let message = match result {
+                                    crate::agent::copilot_auth::GithubCopilotAuthFlowResult::AlreadyAvailable => {
+                                        "GitHub Copilot auth already available".to_string()
+                                    }
+                                    crate::agent::copilot_auth::GithubCopilotAuthFlowResult::ImportedFromGhCli => {
+                                        "Imported GitHub Copilot auth from GitHub CLI".to_string()
+                                    }
+                                    crate::agent::copilot_auth::GithubCopilotAuthFlowResult::Started => {
+                                        "Started GitHub Copilot browser login".to_string()
+                                    }
+                                };
+                                framed
+                                    .send(DaemonMessage::AgentProviderLoginResult {
+                                        provider_id: provider_id.clone(),
+                                        success: true,
+                                        message: Some(message),
+                                    })
+                                    .await?;
+                            }
+                            Err(error) => {
+                                framed
+                                    .send(DaemonMessage::AgentProviderLoginResult {
+                                        provider_id: provider_id.clone(),
+                                        success: false,
+                                        message: Some(error.to_string()),
+                                    })
+                                    .await?;
+                            }
+                        }
+
+                        let states = agent.get_provider_auth_states().await;
+                        let json = serde_json::to_string(&states).unwrap_or_default();
+                        framed
+                            .send(DaemonMessage::AgentProviderAuthStates { states_json: json })
+                            .await?;
+                        continue;
+                    }
+
                     // Surgical update: modify only the target provider's key.
                     let mut config = agent.get_config().await;
                     let entry = config
@@ -652,7 +696,18 @@ if matches!(
                                 model: def.map(|d| d.default_model.to_string()).unwrap_or_default(),
                                 api_key: String::new(),
                                 assistant_id: String::new(),
-                                auth_source: crate::agent::types::AuthSource::ApiKey,
+                                auth_source: auth_source
+                                    .as_deref()
+                                    .map(|value| match value {
+                                        "chatgpt_subscription" => {
+                                            crate::agent::types::AuthSource::ChatgptSubscription
+                                        }
+                                        "github_copilot" => {
+                                            crate::agent::types::AuthSource::GithubCopilot
+                                        }
+                                        _ => crate::agent::types::AuthSource::ApiKey,
+                                    })
+                                    .unwrap_or(crate::agent::types::AuthSource::ApiKey),
                                 api_transport:
                                     crate::agent::types::default_api_transport_for_provider(
                                         &provider_id,
@@ -677,6 +732,15 @@ if matches!(
                     entry.api_key = api_key;
                     if !base_url.is_empty() {
                         entry.base_url = base_url;
+                    }
+                    if let Some(auth_source) = auth_source.as_deref() {
+                        entry.auth_source = match auth_source {
+                            "chatgpt_subscription" => {
+                                crate::agent::types::AuthSource::ChatgptSubscription
+                            }
+                            "github_copilot" => crate::agent::types::AuthSource::GithubCopilot,
+                            _ => crate::agent::types::AuthSource::ApiKey,
+                        };
                     }
                     agent.set_config(config).await;
 

--- a/crates/amux-daemon/src/server/tests_part3.rs
+++ b/crates/amux-daemon/src/server/tests_part3.rs
@@ -1011,6 +1011,76 @@ async fn openai_codex_auth_logout_during_pending_clears_pending_state() {
 }
 
 #[tokio::test]
+async fn github_copilot_login_provider_with_browser_auth_returns_login_result() {
+    let _lock = crate::agent::provider_auth_test_env_lock();
+    let db_root = tempfile::tempdir().expect("temp dir");
+    let script_path = db_root.path().join("gh-mock.sh");
+    std::fs::write(
+        &script_path,
+        "#!/bin/sh\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"login\" ]; then\n  exit 0\nfi\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"token\" ]; then\n  printf 'ghu_test_token\\n'\n  exit 0\nfi\nexit 1\n",
+    )
+    .expect("write gh mock");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path)
+            .expect("script metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).expect("chmod gh mock");
+    }
+
+    std::env::set_var("TAMUX_PROVIDER_AUTH_DB_PATH", db_root.path().join("provider-auth.db"));
+    std::env::set_var("PATH", format!("{}:{}", db_root.path().display(), std::env::var("PATH").unwrap_or_default()));
+    std::fs::copy(&script_path, db_root.path().join("gh")).expect("install gh mock");
+
+    let mut conn = spawn_test_connection().await;
+
+    conn.framed
+        .send(ClientMessage::AgentLoginProvider {
+            provider_id: "github-copilot".to_string(),
+            api_key: String::new(),
+            base_url: "https://api.githubcopilot.com".to_string(),
+            auth_source: Some("github_copilot".to_string()),
+        })
+        .await
+        .expect("send copilot login request");
+
+    match conn.recv().await {
+        DaemonMessage::AgentProviderLoginResult {
+            provider_id,
+            success,
+            message,
+        } => {
+            assert_eq!(provider_id, "github-copilot");
+            assert!(success);
+            assert_eq!(message.as_deref(), Some("Started GitHub Copilot browser login"));
+        }
+        other => panic!("expected AgentProviderLoginResult, got {other:?}"),
+    }
+
+    match conn.recv().await {
+        DaemonMessage::AgentProviderAuthStates { states_json } => {
+            let states: serde_json::Value = serde_json::from_str(&states_json).expect("states json");
+            let copilot = states
+                .as_array()
+                .and_then(|items| {
+                    items.iter().find(|item| {
+                        item.get("provider_id").and_then(|v| v.as_str())
+                            == Some("github-copilot")
+                    })
+                })
+                .expect("copilot state present");
+            assert_eq!(copilot.get("authenticated").and_then(|v| v.as_bool()), Some(true));
+        }
+        other => panic!("expected AgentProviderAuthStates, got {other:?}"),
+    }
+
+    conn.shutdown().await;
+    std::env::remove_var("TAMUX_PROVIDER_AUTH_DB_PATH");
+}
+
+#[tokio::test]
 async fn openai_codex_auth_login_after_error_returns_fresh_pending_payload() {
     let _lock = crate::agent::provider_auth_test_env_lock();
     let (_temp_dir, _env_guard) = setup_server_openai_codex_auth_test();

--- a/crates/amux-protocol/src/messages/client.rs
+++ b/crates/amux-protocol/src/messages/client.rs
@@ -120,7 +120,7 @@ pub enum ClientMessage {
     AgentRetireGeneratedTool { tool_name: String },
     AgentValidateProvider { provider_id: String, base_url: String, api_key: String, auth_source: String },
     AgentGetProviderAuthStates,
-    AgentLoginProvider { provider_id: String, api_key: String, #[serde(default)] base_url: String },
+    AgentLoginProvider { provider_id: String, api_key: String, #[serde(default)] base_url: String, #[serde(default)] auth_source: Option<String> },
     AgentLogoutProvider { provider_id: String },
     AgentSetSubAgent { sub_agent_json: String },
     AgentRemoveSubAgent { sub_agent_id: String },

--- a/crates/amux-protocol/src/messages/daemon.rs
+++ b/crates/amux-protocol/src/messages/daemon.rs
@@ -102,6 +102,7 @@ pub enum DaemonMessage {
     AgentGeneratedToolResult { #[serde(default)] operation_id: Option<String>, #[serde(default)] tool_name: Option<String>, result_json: String },
     AgentProviderValidation { #[serde(default)] operation_id: Option<String>, provider_id: String, valid: bool, #[serde(default)] error: Option<String>, #[serde(default)] models_json: Option<String> },
     AgentProviderAuthStates { states_json: String },
+    AgentProviderLoginResult { provider_id: String, success: bool, #[serde(default)] message: Option<String> },
     AgentSubAgentList { sub_agents_json: String },
     AgentSubAgentUpdated { sub_agent_json: String },
     AgentSubAgentRemoved { sub_agent_id: String },

--- a/crates/amux-protocol/src/messages/tests/mod.rs
+++ b/crates/amux-protocol/src/messages/tests/mod.rs
@@ -755,6 +755,55 @@ fn daemon_message_roundtrips_openai_codex_auth_logout_result() {
 }
 
 #[test]
+fn client_message_roundtrips_login_provider_with_auth_source() {
+    let msg = ClientMessage::AgentLoginProvider {
+        provider_id: "github-copilot".to_string(),
+        api_key: String::new(),
+        base_url: "https://api.githubcopilot.com".to_string(),
+        auth_source: Some("github_copilot".to_string()),
+    };
+    let bytes = bincode::serialize(&msg).unwrap();
+    let decoded: ClientMessage = bincode::deserialize(&bytes).unwrap();
+    match decoded {
+        ClientMessage::AgentLoginProvider {
+            provider_id,
+            api_key,
+            base_url,
+            auth_source,
+        } => {
+            assert_eq!(provider_id, "github-copilot");
+            assert!(api_key.is_empty());
+            assert_eq!(base_url, "https://api.githubcopilot.com");
+            assert_eq!(auth_source.as_deref(), Some("github_copilot"));
+        }
+        other => panic!("unexpected variant: {:?}", other),
+    }
+}
+
+#[test]
+fn daemon_message_roundtrips_provider_login_result() {
+    let msg = DaemonMessage::AgentProviderLoginResult {
+        provider_id: "github-copilot".to_string(),
+        success: true,
+        message: Some("Started GitHub Copilot browser login".to_string()),
+    };
+    let bytes = bincode::serialize(&msg).unwrap();
+    let decoded: DaemonMessage = bincode::deserialize(&bytes).unwrap();
+    match decoded {
+        DaemonMessage::AgentProviderLoginResult {
+            provider_id,
+            success,
+            message,
+        } => {
+            assert_eq!(provider_id, "github-copilot");
+            assert!(success);
+            assert_eq!(message.as_deref(), Some("Started GitHub Copilot browser login"));
+        }
+        other => panic!("unexpected variant: {:?}", other),
+    }
+}
+
+#[test]
 fn daemon_message_roundtrips_plugin_api_call_result_with_operation_id() {
     let msg = DaemonMessage::PluginApiCallResult {
         operation_id: Some("op-plugin-1".to_string()),


### PR DESCRIPTION
## Summary
- add a GitHub Copilot auth choice in `tamux setup` so the CLI wizard can reuse the existing browser-login flow instead of forcing API-key setup
- persist the selected provider `auth_source` and thread it through provider login and validation so Copilot browser auth survives later setup steps
- extend the CLI/daemon protocol and tests for provider login results and auth-source-aware login requests

Closes #58.

## Verification
- `cargo test -p tamux-cli setup_wizard::tests -- --nocapture`
- `cargo test -p tamux-protocol provider_login_result -- --nocapture`
- `cargo test -p tamux-protocol login_provider_with_auth_source -- --nocapture`
- `cargo test -p tamux-daemon github_copilot_login_provider_with_browser_auth_returns_login_result -- --nocapture`
- `cargo build -p tamux-cli -p tamux-daemon`
- manual smoke check of patched `tamux setup` in tmux confirmed the new prompt offers browser login for GitHub Copilot