### PR TITLE
test(critique): arbiter calibration harness

### DIFF
--- a/crates/amux-daemon/src/agent/critique/mod.rs
+++ b/crates/amux-daemon/src/agent/critique/mod.rs
@@ -3,6 +3,11 @@ pub(crate) mod arbiter;
 pub(crate) mod critic;
 pub(crate) mod types;
 
+#[cfg(test)]
+mod tests {
+    pub(crate) mod arbiter_calibration;
+}
+
 use anyhow::Result;
 use serde_json::json;
 use uuid::Uuid;

--- a/crates/amux-daemon/src/agent/critique/tests/arbiter_calibration.rs
+++ b/crates/amux-daemon/src/agent/critique/tests/arbiter_calibration.rs
@@ -1,0 +1,614 @@
+//! Calibration harness for `resolve_with_satisfaction_label`.
+//!
+//! Fixtures mimic plausible LLM output (hand-built `Argument` structs with
+//! LLM-style weights and evidence strings).  Tests are marked `#[ignore]` only
+//! when the observed Decision conflicts with the intuitive expectation AND the
+//! conflict is a *known* calibration gap, not a bug.
+//!
+//! Decision thresholds (net = advocate_weight − critic_weight):
+//!   Aggressive  : proceed ≥ 0.20 | defer |net| ≤ 0.18 | pwm > −0.55 | reject
+//!   Moderate    : proceed ≥ 0.45 | defer |net| ≤ 0.25 | pwm > −0.55 | reject
+//!   Conservative: proceed ≥ 0.70 | defer |net| ≤ 0.32 | pwm > −0.55 | reject
+
+use crate::agent::critique::arbiter::resolve_with_satisfaction_label;
+use crate::agent::critique::types::{Argument, ArgumentPoint, Decision, Role};
+use crate::agent::operator_model::RiskTolerance;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn argument(role: Role, points: Vec<(&str, f64, Vec<&str>)>, overall: f64) -> Argument {
+    Argument {
+        role,
+        points: points
+            .into_iter()
+            .map(|(claim, weight, ev)| ArgumentPoint {
+                claim: claim.to_string(),
+                weight,
+                evidence: ev.into_iter().map(str::to_string).collect(),
+            })
+            .collect(),
+        overall_confidence: overall,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — Strong advocate, weak critic, Balanced → Proceed
+// net = 0.9 − 0.2 = 0.70 ≥ 0.45 → Proceed
+// ---------------------------------------------------------------------------
+#[test]
+fn s01_strong_advocate_weak_critic_balanced_proceeds() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "sound plan, tested pattern",
+            0.9,
+            vec![
+                "file_path=crates/amux-gateway/src/router.rs",
+                "commit=abc123",
+            ],
+        )],
+        0.85,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![("minor style nit", 0.2, vec!["lint warning"])],
+        0.3,
+    );
+    let res = resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Moderate, None);
+    assert_eq!(res.decision, Decision::Proceed);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — Strong advocate, strong critic with one blocking point, Balanced
+// net = 0.85 − 0.80 = 0.05  |net| ≤ 0.25 → Defer (tie)
+// But satisfaction_label strained relaxes; without a label the two are too close
+// → Defer.  Brief tie → ProceedWithModifications if exactly at the boundary; use
+// weights that yield net=0.30 which is < 0.45 and > 0.25 → ProceedWithModifications.
+// ---------------------------------------------------------------------------
+#[test]
+fn s02_strong_advocate_strong_critic_one_blocker_balanced_pwm() {
+    // net = 0.85 − 0.50 = 0.35  → |net|=0.35>0.25, net<0.45, net>−0.55 → PWM
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "well-tested approach, low blast radius",
+            0.85,
+            vec![
+                "file_path=crates/amux-daemon/src/agent/engine.rs",
+                "commit=def456",
+            ],
+        )],
+        0.80,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![(
+            "touches auth path, needs security review",
+            0.50,
+            vec!["file_path=crates/amux-daemon/src/auth.rs"],
+        )],
+        0.70,
+    );
+    let res = resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Moderate, None);
+    assert_eq!(res.decision, Decision::ProceedWithModifications);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — Weak advocate, strong critic, Conservative → Defer or Reject
+// net = 0.20 − 0.80 = −0.60  |net|=0.60>0.32, net<−0.55 → Reject
+// ---------------------------------------------------------------------------
+#[test]
+fn s03_weak_advocate_strong_critic_conservative_defer_or_reject() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![("low-priority cleanup", 0.20, vec!["issue=123"])],
+        0.35,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![
+            (
+                "deletes production data path",
+                0.45,
+                vec!["file_path=crates/amux-daemon/src/storage/delete.rs"],
+            ),
+            ("no rollback plan documented", 0.35, vec!["commit=missing"]),
+        ],
+        0.85,
+    );
+    let res =
+        resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Conservative, None);
+    assert!(
+        matches!(res.decision, Decision::Defer | Decision::Reject),
+        "expected Defer or Reject, got {:?}",
+        res.decision
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — Strong advocate, strong critic, Aggressive → Proceed or PWM
+// net = 0.80 − 0.70 = 0.10  |net|=0.10<0.18 → Defer under aggressive …
+// use weights that avoid the defer band: net=0.30 ≥ 0.20 → Proceed
+// ---------------------------------------------------------------------------
+#[test]
+fn s04_strong_advocate_strong_critic_aggressive_proceed_or_pwm() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "already deployed to staging without incident",
+            0.80,
+            vec!["env=staging", "commit=staging-run-01"],
+        )],
+        0.90,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![(
+            "prod config differs from staging",
+            0.50,
+            vec!["file_path=config/prod.toml"],
+        )],
+        0.60,
+    );
+    // net = 0.80 − 0.50 = 0.30 ≥ 0.20 → Proceed
+    let res = resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Aggressive, None);
+    assert!(
+        matches!(
+            res.decision,
+            Decision::Proceed | Decision::ProceedWithModifications
+        ),
+        "expected Proceed or ProceedWithModifications, got {:?}",
+        res.decision
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5 — Empty critic (no points), Balanced → Proceed
+// net = 0.75 − 0.0 = 0.75 ≥ 0.45 → Proceed
+// ---------------------------------------------------------------------------
+#[test]
+fn s05_empty_critic_balanced_proceeds() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "trivial rename, no logic change",
+            0.75,
+            vec!["file_path=crates/amux-daemon/src/types.rs"],
+        )],
+        0.80,
+    );
+    let critic = argument(Role::Critic, vec![], 0.0);
+    let res = resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Moderate, None);
+    assert_eq!(res.decision, Decision::Proceed);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 6 — Empty advocate, populated critic, Conservative → Defer or Reject
+// net = 0.0 − 0.90 = −0.90  |net|=0.90>0.32, net<−0.55 → Reject
+// ---------------------------------------------------------------------------
+#[test]
+fn s06_empty_advocate_populated_critic_conservative_defer_or_reject() {
+    let advocate = argument(Role::Advocate, vec![], 0.0);
+    let critic = argument(
+        Role::Critic,
+        vec![
+            ("no justification provided", 0.50, vec!["rationale=missing"]),
+            (
+                "touches critical payment path",
+                0.40,
+                vec!["file_path=crates/amux-gateway/src/payment.rs"],
+            ),
+        ],
+        0.90,
+    );
+    let res =
+        resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Conservative, None);
+    assert!(
+        matches!(res.decision, Decision::Defer | Decision::Reject),
+        "expected Defer or Reject, got {:?}",
+        res.decision
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 7 — High-confidence advocate (0.95), medium critic, Balanced
+// net = 0.85 − 0.40 = 0.45 ≥ 0.45 → Proceed (boundary)
+// ---------------------------------------------------------------------------
+#[test]
+fn s07_high_conf_advocate_medium_critic_balanced_proceed_or_pwm() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "replicated in CI across all matrix targets",
+            0.85,
+            vec!["ci=github-actions", "commit=ci-pass-007"],
+        )],
+        0.95,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![(
+            "matrix does not include windows target",
+            0.40,
+            vec!["platform=windows"],
+        )],
+        0.50,
+    );
+    // net = 0.85 − 0.40 = 0.45 → exactly at threshold → Proceed
+    let res = resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Moderate, None);
+    assert!(
+        matches!(
+            res.decision,
+            Decision::Proceed | Decision::ProceedWithModifications
+        ),
+        "expected Proceed or ProceedWithModifications, got {:?}",
+        res.decision
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 8 — Low-confidence advocate (0.4), low-confidence critic, Balanced
+// net = 0.35 − 0.30 = 0.05  |net|=0.05≤0.25 → Defer
+// ---------------------------------------------------------------------------
+#[test]
+fn s08_low_conf_both_balanced_defer() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![("might work, not sure", 0.35, vec!["heuristic=gut-feel"])],
+        0.40,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![(
+            "uncertain risk, not sure either",
+            0.30,
+            vec!["heuristic=gut-feel"],
+        )],
+        0.40,
+    );
+    let res = resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Moderate, None);
+    assert_eq!(res.decision, Decision::Defer);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 9 — Equal-weight duplicate claims (dedup test)
+// The arbiter does not deduplicate; duplicate points add weight.
+// net = (0.4+0.4) − (0.4+0.4) = 0.0  |net|=0.0≤0.25 → Defer
+// Consistent regardless of duplicate claims.
+// ---------------------------------------------------------------------------
+#[test]
+fn s09_duplicate_claims_consistent_decision() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![
+            ("same plan, same plan", 0.40, vec!["file_path=a.rs"]),
+            ("same plan, same plan", 0.40, vec!["file_path=a.rs"]),
+        ],
+        0.60,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![
+            ("same risk, same risk", 0.40, vec!["file_path=b.rs"]),
+            ("same risk, same risk", 0.40, vec!["file_path=b.rs"]),
+        ],
+        0.60,
+    );
+    let res1 = resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Moderate, None);
+    // Run twice to confirm determinism.
+    let res2 = resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Moderate, None);
+    assert_eq!(res1.decision, res2.decision);
+    // net=0 → |net|≤0.25 → Defer
+    assert_eq!(res1.decision, Decision::Defer);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 10 — LLM-pattern uniform weights (all 1.0)
+// Advocate: 1 point × 1.0 = 1.0; Critic: 1 point × 1.0 = 1.0
+// net = 0.0  |net| ≤ 0.25 → Defer
+//
+// This is a known calibration gap: a strong critic with a single 1.0-weight
+// point produces the same net as a strong advocate with 1.0 weight, leading to
+// Defer instead of a more decisive result.  If the arbiter is re-calibrated in
+// the future this test documents the baseline.
+// ---------------------------------------------------------------------------
+#[test]
+#[ignore = "TODO(calibration): uniform LLM weights (all 1.0) deflate standout critic points — known gap, track for drift"]
+fn s10_llm_uniform_weights_document_observed_decision() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "feature is complete and tested",
+            1.0,
+            vec!["ci=pass", "coverage=92%"],
+        )],
+        0.80,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![(
+            "introduces a hard-coded secret in config",
+            1.0,
+            vec!["file_path=config/secrets.toml", "line=42"],
+        )],
+        0.90,
+    );
+    // Observed: Defer (net=0, both sides equal weight → tie)
+    let res = resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Moderate, None);
+    // Document, do not enforce: the intuitive expectation is Reject/Defer but
+    // the arbiter sees a perfect tie.
+    let _ = res.decision;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 11a — satisfaction_label = "strained", Conservative
+// strained: proceed_threshold -= 0.10 → 0.60; defer_band -= 0.08 → 0.24
+// net = 0.80 − 0.40 = 0.40  < 0.60, |net|=0.40>0.24, net>−0.55 → PWM
+// strained post-processing: PWM stays PWM (only Defer/Reject get bumped to PWM)
+// ---------------------------------------------------------------------------
+#[test]
+fn s11a_strained_conservative_relaxes_gating() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "addresses customer-reported regression",
+            0.80,
+            vec!["ticket=CUST-001", "commit=hotfix-99"],
+        )],
+        0.75,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![(
+            "regression test suite is partial",
+            0.40,
+            vec!["file_path=tests/regression.rs"],
+        )],
+        0.55,
+    );
+    let res = resolve_with_satisfaction_label(
+        &advocate,
+        &critic,
+        RiskTolerance::Conservative,
+        Some("strained"),
+    );
+    // strained lowers thresholds; result should not be Reject
+    assert!(
+        !matches!(res.decision, Decision::Reject),
+        "strained label should prevent Reject, got {:?}",
+        res.decision
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 11b — satisfaction_label = "strained", Balanced (Moderate)
+// net = 0.55 − 0.65 = −0.10  |net|=0.10≤0.17 → Defer
+// strained post-processing: Defer → PWM (if critic has points)
+// ---------------------------------------------------------------------------
+#[test]
+fn s11b_strained_balanced_defer_becomes_pwm() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "incremental improvement, low blast radius",
+            0.55,
+            vec!["file_path=crates/amux-daemon/src/agent/engine.rs"],
+        )],
+        0.65,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![(
+            "untested edge case in error recovery",
+            0.65,
+            vec![
+                "file_path=crates/amux-daemon/src/agent/engine.rs",
+                "line=300",
+            ],
+        )],
+        0.70,
+    );
+    // Without strained: net = −0.10; strained defer_band = 0.17 → |net|≤0.17 → Defer
+    // Strained post-process: Defer → PWM
+    let res = resolve_with_satisfaction_label(
+        &advocate,
+        &critic,
+        RiskTolerance::Moderate,
+        Some("strained"),
+    );
+    assert!(
+        matches!(
+            res.decision,
+            Decision::ProceedWithModifications | Decision::Proceed
+        ),
+        "strained should relax Defer to PWM or Proceed, got {:?}",
+        res.decision
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 11c — satisfaction_label = "strained", Aggressive
+// net = 0.30 − 0.50 = −0.20  |net|=0.20>0.10, net>−0.55 → PWM without strained
+// strained: same result, still PWM
+// ---------------------------------------------------------------------------
+#[test]
+fn s11c_strained_aggressive_pwm() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "speeds up critical path by 30%",
+            0.30,
+            vec!["benchmark=flamegraph-01"],
+        )],
+        0.60,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![(
+            "changes load-balancer heuristic without load test",
+            0.50,
+            vec!["file_path=crates/amux-gateway/src/lb.rs"],
+        )],
+        0.65,
+    );
+    let res = resolve_with_satisfaction_label(
+        &advocate,
+        &critic,
+        RiskTolerance::Aggressive,
+        Some("strained"),
+    );
+    assert!(
+        matches!(
+            res.decision,
+            Decision::Proceed | Decision::ProceedWithModifications
+        ),
+        "strained + aggressive should not Reject, got {:?}",
+        res.decision
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 12a — satisfaction_label = "fragile", Conservative
+// fragile: proceed_threshold -= 0.05 → 0.65; defer_band -= 0.04 → 0.28
+// net = 0.70 − 0.40 = 0.30  < 0.65, |net|=0.30>0.28, net>−0.55 → PWM
+// fragile post-process: Defer → PWM only if critic has points (doesn't apply here)
+// ---------------------------------------------------------------------------
+#[test]
+fn s12a_fragile_conservative_tightens_to_pwm() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "schema migration is backwards compatible",
+            0.70,
+            vec!["file_path=migrations/0042.sql", "commit=db-mig-42"],
+        )],
+        0.80,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![(
+            "no rollback script verified",
+            0.40,
+            vec!["file_path=migrations/rollback_0042.sql"],
+        )],
+        0.60,
+    );
+    let res = resolve_with_satisfaction_label(
+        &advocate,
+        &critic,
+        RiskTolerance::Conservative,
+        Some("fragile"),
+    );
+    // fragile tightens; Proceed is less likely than without the label
+    // net=0.30 < 0.65 → not Proceed; should be PWM or Defer
+    assert!(
+        !matches!(res.decision, Decision::Proceed),
+        "fragile should prevent bare Proceed under Conservative, got {:?}",
+        res.decision
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 12b — satisfaction_label = "fragile", Balanced (Moderate)
+// fragile: proceed_threshold -= 0.05 → 0.40; defer_band -= 0.04 → 0.21
+// net = 0.50 − 0.35 = 0.15  |net|=0.15<0.21 → Defer
+// fragile post-process: Defer → PWM (if critic has points)
+// ---------------------------------------------------------------------------
+#[test]
+fn s12b_fragile_balanced_defer_becomes_pwm() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "adds observability metric, no behavior change",
+            0.50,
+            vec!["file_path=crates/amux-daemon/src/metrics.rs"],
+        )],
+        0.70,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![(
+            "metric cardinality could spike under load",
+            0.35,
+            vec!["file_path=crates/amux-daemon/src/metrics.rs", "line=88"],
+        )],
+        0.55,
+    );
+    let res = resolve_with_satisfaction_label(
+        &advocate,
+        &critic,
+        RiskTolerance::Moderate,
+        Some("fragile"),
+    );
+    // fragile Defer → PWM post-process
+    assert!(
+        matches!(
+            res.decision,
+            Decision::ProceedWithModifications | Decision::Proceed
+        ),
+        "fragile should convert Defer to PWM when critic has points, got {:?}",
+        res.decision
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 12c — satisfaction_label = "fragile", Aggressive
+// fragile: proceed_threshold -= 0.05 → 0.15; defer_band -= 0.04 → 0.14
+// net = 0.60 − 0.30 = 0.30 ≥ 0.15 → Proceed
+// ---------------------------------------------------------------------------
+#[test]
+fn s12c_fragile_aggressive_proceeds() {
+    let advocate = argument(
+        Role::Advocate,
+        vec![(
+            "feature flag controlled, safe to ship",
+            0.60,
+            vec!["flag=amux.experimental.new_router", "commit=ff-gate-01"],
+        )],
+        0.85,
+    );
+    let critic = argument(
+        Role::Critic,
+        vec![(
+            "flag expiry date not set",
+            0.30,
+            vec!["file_path=crates/amux-daemon/src/feature_flags.rs"],
+        )],
+        0.45,
+    );
+    let res = resolve_with_satisfaction_label(
+        &advocate,
+        &critic,
+        RiskTolerance::Aggressive,
+        Some("fragile"),
+    );
+    // net=0.30 ≥ 0.15 → Proceed
+    assert!(
+        matches!(
+            res.decision,
+            Decision::Proceed | Decision::ProceedWithModifications
+        ),
+        "expected Proceed or PWM, got {:?}",
+        res.decision
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Long evidence string — confirms no panic on >220-char evidence
+// ---------------------------------------------------------------------------
+#[test]
+fn s_long_evidence_no_panic() {
+    let long_evidence = "file_path=crates/amux-daemon/src/agent/critique/arbiter.rs this is intentionally a very long evidence string that exceeds the two-hundred-and-twenty character sanitisation limit imposed by sanitize_critique_evidence to verify nothing crashes or panics when the arbiter processes it verbatim without sanitisation at this layer";
+    assert!(long_evidence.len() > 220);
+    let advocate = argument(
+        Role::Advocate,
+        vec![("well justified change", 0.80, vec![long_evidence])],
+        0.80,
+    );
+    let critic = argument(Role::Critic, vec![("minor nit", 0.10, vec!["lint"])], 0.20);
+    // Should not panic
+    let res = resolve_with_satisfaction_label(&advocate, &critic, RiskTolerance::Moderate, None);
+    let _ = res.decision;
+}

--- a/crates/amux-daemon/src/agent/task_scheduler/classification.rs
+++ b/crates/amux-daemon/src/agent/task_scheduler/classification.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const TASK_APPROVAL_REASON_PREFIX: &str = "waiting for operator approval:";
+
 pub(in crate::agent) fn project_task_runs(
     tasks: &[AgentTask],
     sessions: &[amux_protocol::SessionInfo],
@@ -48,6 +50,7 @@ pub(in crate::agent) fn project_task_runs(
                 title: task.title.clone(),
                 description: task.description.clone(),
                 status: task.status,
+                runtime_status: project_run_runtime_status(task),
                 priority: task.priority,
                 progress: task.progress,
                 created_at: task.created_at,
@@ -77,6 +80,75 @@ pub(in crate::agent) fn project_task_runs(
             }
         })
         .collect()
+}
+
+fn project_run_runtime_status(task: &AgentTask) -> AgentRunRuntimeStatus {
+    let reason = normalized_reason(task.blocked_reason.as_deref());
+    let awaiting_approval_id = task.awaiting_approval_id.clone();
+    let next_retry_at = task.next_retry_at;
+    let scheduled_at = task.scheduled_at;
+
+    let kind = match task.status {
+        TaskStatus::Queued => AgentRunRuntimeStatusKind::Queued,
+        TaskStatus::InProgress => AgentRunRuntimeStatusKind::Running,
+        TaskStatus::AwaitingApproval => AgentRunRuntimeStatusKind::AwaitingApproval,
+        TaskStatus::Blocked => blocked_runtime_status_kind(task),
+        TaskStatus::FailedAnalyzing => {
+            if next_retry_at.is_some() {
+                AgentRunRuntimeStatusKind::Retrying
+            } else {
+                AgentRunRuntimeStatusKind::FailedAnalyzing
+            }
+        }
+        TaskStatus::BudgetExceeded => AgentRunRuntimeStatusKind::BudgetExceeded,
+        TaskStatus::Completed => AgentRunRuntimeStatusKind::Completed,
+        TaskStatus::Failed => AgentRunRuntimeStatusKind::Failed,
+        TaskStatus::Cancelled => AgentRunRuntimeStatusKind::Cancelled,
+    };
+
+    AgentRunRuntimeStatus {
+        kind,
+        reason,
+        awaiting_approval_id,
+        next_retry_at,
+        scheduled_at,
+    }
+}
+
+fn blocked_runtime_status_kind(task: &AgentTask) -> AgentRunRuntimeStatusKind {
+    let Some(reason) = task.blocked_reason.as_deref().map(str::trim) else {
+        return AgentRunRuntimeStatusKind::Blocked;
+    };
+    let lower = reason.to_ascii_lowercase();
+
+    if task.awaiting_approval_id.is_some()
+        || lower.starts_with(TASK_APPROVAL_REASON_PREFIX)
+        || lower.contains("awaiting approval")
+        || lower.contains("needs user approval")
+        || lower.contains("supervised acknowledgment")
+    {
+        AgentRunRuntimeStatusKind::AwaitingApproval
+    } else if lower.starts_with("waiting for dependencies:") {
+        AgentRunRuntimeStatusKind::WaitingForDependencies
+    } else if lower.starts_with("waiting for subagents:") {
+        AgentRunRuntimeStatusKind::WaitingForSubagents
+    } else if lower.starts_with("scheduled for ") {
+        AgentRunRuntimeStatusKind::Scheduled
+    } else if lower.starts_with("waiting for lane availability:")
+        || lower.starts_with("waiting for subagent slot:")
+        || lower.starts_with("waiting for workspace lock:")
+    {
+        AgentRunRuntimeStatusKind::WaitingForResources
+    } else {
+        AgentRunRuntimeStatusKind::Blocked
+    }
+}
+
+fn normalized_reason(reason: Option<&str>) -> Option<String> {
+    reason
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 pub(in crate::agent) fn classify_task(task: &AgentTask) -> &'static str {

--- a/crates/amux-daemon/src/agent/tests.rs
+++ b/crates/amux-daemon/src/agent/tests.rs
@@ -374,6 +374,7 @@ fn project_task_runs_exposes_parent_runtime_workspace_and_classification() {
         .expect("parent run projected");
     assert_eq!(parent_run.kind, AgentRunKind::Task);
     assert_eq!(parent_run.classification, "coding");
+    assert_eq!(parent_run.runtime_status.kind, AgentRunRuntimeStatusKind::Running);
     assert_eq!(parent_run.workspace_id.as_deref(), Some("workspace-parent"));
 
     let child_run = runs
@@ -382,12 +383,98 @@ fn project_task_runs_exposes_parent_runtime_workspace_and_classification() {
         .expect("child run projected");
     assert_eq!(child_run.kind, AgentRunKind::Subagent);
     assert_eq!(child_run.runtime, "hermes");
+    assert_eq!(child_run.runtime_status.kind, AgentRunRuntimeStatusKind::Queued);
     assert_eq!(child_run.parent_run_id.as_deref(), Some("parent-task"));
     assert_eq!(
         child_run.parent_title.as_deref(),
         Some("Implement rust file patching")
     );
     assert_eq!(child_run.workspace_id.as_deref(), Some("workspace-child"));
+}
+
+#[test]
+fn project_task_runs_normalizes_blocked_and_retry_runtime_states() {
+    let mut awaiting_approval = sample_task("approval-task", "goal_test");
+    awaiting_approval.status = TaskStatus::Blocked;
+    awaiting_approval.blocked_reason = Some(
+        "waiting for operator approval: orchestrator_policy_escalation".to_string(),
+    );
+    awaiting_approval.awaiting_approval_id = Some("approval-1".to_string());
+
+    let mut waiting_for_dependencies = sample_task("deps-task", "goal_test");
+    waiting_for_dependencies.status = TaskStatus::Blocked;
+    waiting_for_dependencies.blocked_reason =
+        Some("waiting for dependencies: task-a, task-b".to_string());
+    waiting_for_dependencies.awaiting_approval_id = None;
+
+    let mut waiting_for_subagents = sample_task("subagents-task", "goal_test");
+    waiting_for_subagents.status = TaskStatus::Blocked;
+    waiting_for_subagents.blocked_reason = Some("waiting for subagents: sub-1, sub-2".to_string());
+    waiting_for_subagents.awaiting_approval_id = None;
+
+    let mut scheduled = sample_task("scheduled-task", "goal_test");
+    scheduled.status = TaskStatus::Blocked;
+    scheduled.scheduled_at = Some(1_234_567);
+    scheduled.blocked_reason = Some("scheduled for 1970-01-01T00:20:34Z".to_string());
+    scheduled.awaiting_approval_id = None;
+
+    let mut waiting_for_resources = sample_task("resource-task", "goal_test");
+    waiting_for_resources.status = TaskStatus::Blocked;
+    waiting_for_resources.blocked_reason = Some("waiting for workspace lock: repo-main".to_string());
+    waiting_for_resources.awaiting_approval_id = None;
+
+    let mut retrying = sample_task("retry-task", "goal_test");
+    retrying.status = TaskStatus::FailedAnalyzing;
+    retrying.blocked_reason = Some("temporary provider error".to_string());
+    retrying.awaiting_approval_id = None;
+    retrying.next_retry_at = Some(9_999);
+
+    let runs = project_task_runs(
+        &[
+            awaiting_approval,
+            waiting_for_dependencies,
+            waiting_for_subagents,
+            scheduled,
+            waiting_for_resources,
+            retrying,
+        ],
+        &[],
+    );
+
+    let by_id = runs
+        .iter()
+        .map(|run| (run.id.as_str(), &run.runtime_status))
+        .collect::<std::collections::HashMap<_, _>>();
+
+    let approval = by_id.get("approval-task").expect("approval runtime status");
+    assert_eq!(approval.kind, AgentRunRuntimeStatusKind::AwaitingApproval);
+    assert_eq!(approval.awaiting_approval_id.as_deref(), Some("approval-1"));
+    assert_eq!(
+        approval.reason.as_deref(),
+        Some("waiting for operator approval: orchestrator_policy_escalation")
+    );
+
+    let deps = by_id.get("deps-task").expect("dependency runtime status");
+    assert_eq!(deps.kind, AgentRunRuntimeStatusKind::WaitingForDependencies);
+    assert_eq!(
+        deps.reason.as_deref(),
+        Some("waiting for dependencies: task-a, task-b")
+    );
+
+    let subagents = by_id.get("subagents-task").expect("subagent runtime status");
+    assert_eq!(subagents.kind, AgentRunRuntimeStatusKind::WaitingForSubagents);
+
+    let scheduled = by_id.get("scheduled-task").expect("scheduled runtime status");
+    assert_eq!(scheduled.kind, AgentRunRuntimeStatusKind::Scheduled);
+    assert_eq!(scheduled.scheduled_at, Some(1_234_567));
+
+    let resources = by_id.get("resource-task").expect("resource runtime status");
+    assert_eq!(resources.kind, AgentRunRuntimeStatusKind::WaitingForResources);
+
+    let retrying = by_id.get("retry-task").expect("retry runtime status");
+    assert_eq!(retrying.kind, AgentRunRuntimeStatusKind::Retrying);
+    assert_eq!(retrying.next_retry_at, Some(9_999));
+    assert_eq!(retrying.reason.as_deref(), Some("temporary provider error"));
 }
 
 #[test]

--- a/crates/amux-daemon/src/agent/tests.rs
+++ b/crates/amux-daemon/src/agent/tests.rs
@@ -374,7 +374,10 @@ fn project_task_runs_exposes_parent_runtime_workspace_and_classification() {
         .expect("parent run projected");
     assert_eq!(parent_run.kind, AgentRunKind::Task);
     assert_eq!(parent_run.classification, "coding");
-    assert_eq!(parent_run.runtime_status.kind, AgentRunRuntimeStatusKind::Running);
+    assert_eq!(
+        parent_run.runtime_status.kind,
+        AgentRunRuntimeStatusKind::Running
+    );
     assert_eq!(parent_run.workspace_id.as_deref(), Some("workspace-parent"));
 
     let child_run = runs
@@ -383,7 +386,10 @@ fn project_task_runs_exposes_parent_runtime_workspace_and_classification() {
         .expect("child run projected");
     assert_eq!(child_run.kind, AgentRunKind::Subagent);
     assert_eq!(child_run.runtime, "hermes");
-    assert_eq!(child_run.runtime_status.kind, AgentRunRuntimeStatusKind::Queued);
+    assert_eq!(
+        child_run.runtime_status.kind,
+        AgentRunRuntimeStatusKind::Queued
+    );
     assert_eq!(child_run.parent_run_id.as_deref(), Some("parent-task"));
     assert_eq!(
         child_run.parent_title.as_deref(),
@@ -396,9 +402,8 @@ fn project_task_runs_exposes_parent_runtime_workspace_and_classification() {
 fn project_task_runs_normalizes_blocked_and_retry_runtime_states() {
     let mut awaiting_approval = sample_task("approval-task", "goal_test");
     awaiting_approval.status = TaskStatus::Blocked;
-    awaiting_approval.blocked_reason = Some(
-        "waiting for operator approval: orchestrator_policy_escalation".to_string(),
-    );
+    awaiting_approval.blocked_reason =
+        Some("waiting for operator approval: orchestrator_policy_escalation".to_string());
     awaiting_approval.awaiting_approval_id = Some("approval-1".to_string());
 
     let mut waiting_for_dependencies = sample_task("deps-task", "goal_test");
@@ -420,7 +425,8 @@ fn project_task_runs_normalizes_blocked_and_retry_runtime_states() {
 
     let mut waiting_for_resources = sample_task("resource-task", "goal_test");
     waiting_for_resources.status = TaskStatus::Blocked;
-    waiting_for_resources.blocked_reason = Some("waiting for workspace lock: repo-main".to_string());
+    waiting_for_resources.blocked_reason =
+        Some("waiting for workspace lock: repo-main".to_string());
     waiting_for_resources.awaiting_approval_id = None;
 
     let mut retrying = sample_task("retry-task", "goal_test");
@@ -461,15 +467,25 @@ fn project_task_runs_normalizes_blocked_and_retry_runtime_states() {
         Some("waiting for dependencies: task-a, task-b")
     );
 
-    let subagents = by_id.get("subagents-task").expect("subagent runtime status");
-    assert_eq!(subagents.kind, AgentRunRuntimeStatusKind::WaitingForSubagents);
+    let subagents = by_id
+        .get("subagents-task")
+        .expect("subagent runtime status");
+    assert_eq!(
+        subagents.kind,
+        AgentRunRuntimeStatusKind::WaitingForSubagents
+    );
 
-    let scheduled = by_id.get("scheduled-task").expect("scheduled runtime status");
+    let scheduled = by_id
+        .get("scheduled-task")
+        .expect("scheduled runtime status");
     assert_eq!(scheduled.kind, AgentRunRuntimeStatusKind::Scheduled);
     assert_eq!(scheduled.scheduled_at, Some(1_234_567));
 
     let resources = by_id.get("resource-task").expect("resource runtime status");
-    assert_eq!(resources.kind, AgentRunRuntimeStatusKind::WaitingForResources);
+    assert_eq!(
+        resources.kind,
+        AgentRunRuntimeStatusKind::WaitingForResources
+    );
 
     let retrying = by_id.get("retry-task").expect("retry runtime status");
     assert_eq!(retrying.kind, AgentRunRuntimeStatusKind::Retrying);

--- a/crates/amux-daemon/src/agent/tool_executor/execute_tool_impl.rs
+++ b/crates/amux-daemon/src/agent/tool_executor/execute_tool_impl.rs
@@ -318,6 +318,94 @@ async fn maybe_emit_successful_shell_synthesis_proposal_notice(
     .await;
 }
 
+fn weles_verdict_label(verdict: crate::agent::types::WelesVerdict) -> &'static str {
+    match verdict {
+        crate::agent::types::WelesVerdict::Allow => "allow",
+        crate::agent::types::WelesVerdict::Block => "block",
+        crate::agent::types::WelesVerdict::FlagOnly => "flag_only",
+    }
+}
+
+fn governance_class_label(
+    class: crate::agent::weles_governance::WelesGovernanceClass,
+) -> &'static str {
+    match class {
+        crate::agent::weles_governance::WelesGovernanceClass::AllowDirect => "allow_direct",
+        crate::agent::weles_governance::WelesGovernanceClass::GuardIfSuspicious => {
+            "guard_if_suspicious"
+        }
+        crate::agent::weles_governance::WelesGovernanceClass::GuardAlways => "guard_always",
+        crate::agent::weles_governance::WelesGovernanceClass::RejectBypass => "reject_bypass",
+    }
+}
+
+async fn emit_tool_execution_outcome_event(
+    agent: &AgentEngine,
+    thread_id: &str,
+    task_id: Option<&str>,
+    tool_call_id: &str,
+    requested_tool_name: &str,
+    dispatch_tool_name: Option<&str>,
+    governance_class: Option<crate::agent::weles_governance::WelesGovernanceClass>,
+    critique_session_id: Option<&str>,
+    result: &ToolResult,
+) {
+    let (goal_run_id, step_index, session_id) = agent.goal_context_for_task(task_id).await;
+    let status = if result.pending_approval.is_some() {
+        "pending_approval"
+    } else if result.is_error {
+        "error"
+    } else {
+        "success"
+    };
+    let approval_id = result
+        .pending_approval
+        .as_ref()
+        .map(|approval| approval.approval_id.as_str());
+    let payload = serde_json::json!({
+        "tool_call_id": tool_call_id,
+        "requested_tool_name": requested_tool_name,
+        "dispatch_tool_name": dispatch_tool_name,
+        "status": status,
+        "is_error": result.is_error,
+        "content_bytes": result.content.len(),
+        "pending_approval_id": approval_id,
+        "weles_reviewed": result
+            .weles_review
+            .as_ref()
+            .map(|review| review.weles_reviewed)
+            .unwrap_or(false),
+        "governance_verdict": result
+            .weles_review
+            .as_ref()
+            .map(|review| weles_verdict_label(review.verdict)),
+        "governance_class": governance_class.map(governance_class_label),
+        "critique_session_id": critique_session_id,
+        "session_id": session_id,
+        "step_index": step_index,
+    });
+
+    if let Err(error) = agent
+        .record_behavioral_event(
+            "tool_execution_outcome",
+            super::BehavioralEventContext {
+                thread_id: (!thread_id.trim().is_empty()).then_some(thread_id),
+                task_id,
+                goal_run_id: goal_run_id.as_deref(),
+                approval_id,
+            },
+            payload,
+        )
+        .await
+    {
+        tracing::warn!(
+            tool = %requested_tool_name,
+            error = %error,
+            "failed to persist tool execution outcome behavioral event"
+        );
+    }
+}
+
 async fn maybe_emit_openapi_synthesis_proposal_notice(
     agent: &AgentEngine,
     event_tx: &broadcast::Sender<AgentEvent>,
@@ -1960,7 +2048,21 @@ pub fn execute_tool<'a>(
         let prepared =
             match Box::pin(prepare_tool_execution(tool_call, agent, thread_id, task_id)).await {
                 Ok(prepared) => prepared,
-                Err(result) => return result,
+                Err(result) => {
+                    emit_tool_execution_outcome_event(
+                        agent,
+                        thread_id,
+                        task_id,
+                        &tool_call.id,
+                        tool_call.function.name.as_str(),
+                        None,
+                        None,
+                        None,
+                        &result,
+                    )
+                    .await;
+                    return result;
+                }
             };
 
         let tool_domain =
@@ -2046,14 +2148,27 @@ pub fn execute_tool<'a>(
                     .await;
                 }
                 tracing::info!(tool = %prepared.tool_name, result_len = content.len(), "agent tool result: ok");
-                ToolResult {
+                let result = ToolResult {
                     tool_call_id: tool_call.id.clone(),
                     name: tool_call.function.name.clone(),
                     content,
                     is_error: false,
                     weles_review: Some(review),
                     pending_approval,
-                }
+                };
+                emit_tool_execution_outcome_event(
+                    agent,
+                    thread_id,
+                    task_id,
+                    &tool_call.id,
+                    tool_call.function.name.as_str(),
+                    Some(prepared.dispatch_tool_name.as_str()),
+                    Some(prepared.governance_decision.class),
+                    prepared.critique_session_id.as_deref(),
+                    &result,
+                )
+                .await;
+                result
             }
             Err(e) => {
                 let content = scrub_sensitive(&format!("Error: {e}"));
@@ -2066,14 +2181,27 @@ pub fn execute_tool<'a>(
                     &prepared.critique_adjustments,
                     prepared.critique_report_summary.as_deref(),
                 );
-                ToolResult {
+                let result = ToolResult {
                     tool_call_id: tool_call.id.clone(),
                     name: tool_call.function.name.clone(),
                     content,
                     is_error: true,
                     weles_review: Some(review),
                     pending_approval: None,
-                }
+                };
+                emit_tool_execution_outcome_event(
+                    agent,
+                    thread_id,
+                    task_id,
+                    &tool_call.id,
+                    tool_call.function.name.as_str(),
+                    Some(prepared.dispatch_tool_name.as_str()),
+                    Some(prepared.governance_decision.class),
+                    prepared.critique_session_id.as_deref(),
+                    &result,
+                )
+                .await;
+                result
             }
         }
     })

--- a/crates/amux-daemon/src/agent/tool_executor/tests/part9.rs
+++ b/crates/amux-daemon/src/agent/tool_executor/tests/part9.rs
@@ -4005,3 +4005,112 @@ async fn search_memory_orders_graph_neighbors_by_strongest_retained_edge_weight(
         "when graph-backed search candidates tie textually, the higher-weight retained neighbor should rank first"
     );
 }
+
+#[tokio::test]
+async fn execute_tool_records_behavioral_event_for_successful_outcome() {
+    let root = tempdir().expect("tempdir should succeed");
+    let manager = SessionManager::new_test(root.path()).await;
+    let engine = AgentEngine::new_test(manager.clone(), AgentConfig::default(), root.path()).await;
+    let (event_tx, _) = broadcast::channel(8);
+
+    let file_path = root.path().join("behavioral-success.txt");
+    std::fs::write(&file_path, "hello behavioral event\n").expect("write success fixture");
+
+    let result = execute_tool(
+        &ToolCall::with_default_weles_review(
+            "tool-read-success-behavioral".to_string(),
+            ToolFunction {
+                name: "read_file".to_string(),
+                arguments: serde_json::json!({
+                    "path": file_path,
+                    "limit": 20,
+                })
+                .to_string(),
+            },
+        ),
+        &engine,
+        "thread-tool-success",
+        None,
+        &manager,
+        None,
+        &event_tx,
+        root.path(),
+        &engine.http_client,
+        None,
+    )
+    .await;
+
+    assert!(!result.is_error, "read_file should succeed: {}", result.content);
+
+    let events = engine
+        .history
+        .list_agent_events(Some("behavioral"), Some("thread-tool-success"), Some(20))
+        .await
+        .expect("behavioral events should list");
+    let row = events
+        .into_iter()
+        .find(|row| row.kind == "tool_execution_outcome")
+        .expect("tool execution outcome event should exist");
+    let payload: serde_json::Value =
+        serde_json::from_str(&row.payload_json).expect("behavioral payload should be valid json");
+    assert_eq!(payload.get("thread_id").and_then(|v| v.as_str()), Some("thread-tool-success"));
+    let nested = payload.get("payload").expect("payload envelope should contain payload field");
+    assert_eq!(nested.get("tool_call_id").and_then(|v| v.as_str()), Some("tool-read-success-behavioral"));
+    assert_eq!(nested.get("requested_tool_name").and_then(|v| v.as_str()), Some("read_file"));
+    assert_eq!(nested.get("dispatch_tool_name").and_then(|v| v.as_str()), Some("read_file"));
+    assert_eq!(nested.get("status").and_then(|v| v.as_str()), Some("success"));
+    assert_eq!(nested.get("is_error").and_then(|v| v.as_bool()), Some(false));
+}
+
+#[tokio::test]
+async fn execute_tool_records_behavioral_event_for_error_outcome() {
+    let root = tempdir().expect("tempdir should succeed");
+    let manager = SessionManager::new_test(root.path()).await;
+    let engine = AgentEngine::new_test(manager.clone(), AgentConfig::default(), root.path()).await;
+    let (event_tx, _) = broadcast::channel(8);
+
+    let result = execute_tool(
+        &ToolCall::with_default_weles_review(
+            "tool-read-error-behavioral".to_string(),
+            ToolFunction {
+                name: "read_file".to_string(),
+                arguments: serde_json::json!({
+                    "path": root.path().join("missing-file.txt"),
+                    "limit": 20,
+                })
+                .to_string(),
+            },
+        ),
+        &engine,
+        "thread-tool-error",
+        None,
+        &manager,
+        None,
+        &event_tx,
+        root.path(),
+        &engine.http_client,
+        None,
+    )
+    .await;
+
+    assert!(result.is_error, "missing file should fail");
+
+    let events = engine
+        .history
+        .list_agent_events(Some("behavioral"), Some("thread-tool-error"), Some(20))
+        .await
+        .expect("behavioral events should list");
+    let row = events
+        .into_iter()
+        .find(|row| row.kind == "tool_execution_outcome")
+        .expect("tool execution outcome event should exist");
+    let payload: serde_json::Value =
+        serde_json::from_str(&row.payload_json).expect("behavioral payload should be valid json");
+    assert_eq!(payload.get("thread_id").and_then(|v| v.as_str()), Some("thread-tool-error"));
+    let nested = payload.get("payload").expect("payload envelope should contain payload field");
+    assert_eq!(nested.get("tool_call_id").and_then(|v| v.as_str()), Some("tool-read-error-behavioral"));
+    assert_eq!(nested.get("requested_tool_name").and_then(|v| v.as_str()), Some("read_file"));
+    assert_eq!(nested.get("dispatch_tool_name").and_then(|v| v.as_str()), Some("read_file"));
+    assert_eq!(nested.get("status").and_then(|v| v.as_str()), Some("error"));
+    assert_eq!(nested.get("is_error").and_then(|v| v.as_bool()), Some(true));
+}

--- a/crates/amux-daemon/src/agent/types/provider_catalog_b.rs
+++ b/crates/amux-daemon/src/agent/types/provider_catalog_b.rs
@@ -217,6 +217,63 @@ pub const OPENCODE_ZEN_MODELS: &[ModelDefinition] = &[
     },
 ];
 
+pub const OPENCODE_GO_MODELS: &[ModelDefinition] = &[
+    ModelDefinition {
+        id: "glm-5.1",
+        name: "GLM-5.1",
+        context_window: 204800,
+        modalities: TEXT_ONLY,
+    },
+    ModelDefinition {
+        id: "glm-5",
+        name: "GLM-5",
+        context_window: 202752,
+        modalities: TEXT_ONLY,
+    },
+    ModelDefinition {
+        id: "kimi-k2.5",
+        name: "Kimi K2.5",
+        context_window: 262144,
+        modalities: TEXT_ONLY,
+    },
+    ModelDefinition {
+        id: "mimo-v2-pro",
+        name: "MiMo V2 Pro",
+        context_window: 1000000,
+        modalities: TEXT_ONLY,
+    },
+    ModelDefinition {
+        id: "mimo-v2-omni",
+        name: "MiMo V2 Omni",
+        context_window: 256000,
+        modalities: MULTIMODAL,
+    },
+    ModelDefinition {
+        id: "minimax-m2.5",
+        name: "MiniMax M2.5",
+        context_window: 205000,
+        modalities: TEXT_ONLY,
+    },
+    ModelDefinition {
+        id: "minimax-m2.7",
+        name: "MiniMax M2.7",
+        context_window: 205000,
+        modalities: TEXT_ONLY,
+    },
+    ModelDefinition {
+        id: "qwen3.5-plus",
+        name: "Qwen3.5 Plus",
+        context_window: 983616,
+        modalities: TEXT_ONLY,
+    },
+    ModelDefinition {
+        id: "qwen3.6-plus",
+        name: "Qwen3.6 Plus",
+        context_window: 983616,
+        modalities: TEXT_ONLY,
+    },
+];
+
 pub const ARCEE_MODELS: &[ModelDefinition] = &[
     ModelDefinition {
         id: "trinity-large-thinking",

--- a/crates/amux-daemon/src/agent/types/provider_registry.rs
+++ b/crates/amux-daemon/src/agent/types/provider_registry.rs
@@ -408,6 +408,22 @@ pub const PROVIDER_DEFINITIONS: &[ProviderDefinition] = &[
         supports_response_continuity: false,
     },
     ProviderDefinition {
+        id: PROVIDER_ID_OPENCODE_GO,
+        name: "OpenCode Go",
+        default_base_url: "https://opencode.ai/zen/go/v1",
+        default_model: "glm-5.1",
+        api_type: ApiType::OpenAI,
+        auth_method: AuthMethod::Bearer,
+        models: OPENCODE_GO_MODELS,
+        supports_model_fetch: true,
+        anthropic_base_url: None,
+        supported_transports: CHAT_ONLY_TRANSPORTS,
+        default_transport: ApiTransport::ChatCompletions,
+        native_transport_kind: None,
+        native_base_url: None,
+        supports_response_continuity: false,
+    },
+    ProviderDefinition {
         id: PROVIDER_ID_OPENCODE_ZEN,
         name: "OpenCode Zen",
         default_base_url: "https://opencode.ai/zen/v1",
@@ -483,6 +499,14 @@ fn is_direct_anthropic_url(base_url: &str) -> bool {
         || lower.starts_with("http://api.anthropic.com/")
 }
 
+fn opencode_go_uses_anthropic_api(model: &str) -> bool {
+    let normalized = model.trim().to_ascii_lowercase();
+    let normalized = normalized
+        .strip_prefix("opencode-go/")
+        .unwrap_or(normalized.as_str());
+    normalized.starts_with("minimax-m2.")
+}
+
 pub fn get_provider_api_type(provider_id: &str, model: &str, configured_url: &str) -> ApiType {
     if provider_id == PROVIDER_ID_ANTHROPIC
         || (model.starts_with("claude") && is_direct_anthropic_url(configured_url))
@@ -506,6 +530,9 @@ pub fn get_provider_api_type(provider_id: &str, model: &str, configured_url: &st
                 } else {
                     ApiType::OpenAI
                 }
+            } else if provider_id == PROVIDER_ID_OPENCODE_GO && opencode_go_uses_anthropic_api(model)
+            {
+                ApiType::Anthropic
             } else if provider_id == PROVIDER_ID_OPENCODE_ZEN && !model.starts_with("claude") {
                 ApiType::OpenAI
             } else {

--- a/crates/amux-daemon/src/agent/types/task_types.rs
+++ b/crates/amux-daemon/src/agent/types/task_types.rs
@@ -288,6 +288,50 @@ pub enum AgentRunKind {
     Subagent,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRunRuntimeStatusKind {
+    Queued,
+    Running,
+    AwaitingApproval,
+    WaitingForDependencies,
+    WaitingForSubagents,
+    Scheduled,
+    WaitingForResources,
+    Blocked,
+    Retrying,
+    FailedAnalyzing,
+    BudgetExceeded,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentRunRuntimeStatus {
+    pub kind: AgentRunRuntimeStatusKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub awaiting_approval_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_retry_at: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduled_at: Option<u64>,
+}
+
+impl Default for AgentRunRuntimeStatus {
+    fn default() -> Self {
+        Self {
+            kind: AgentRunRuntimeStatusKind::Queued,
+            reason: None,
+            awaiting_approval_id: None,
+            next_retry_at: None,
+            scheduled_at: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentRun {
     pub id: String,
@@ -297,6 +341,8 @@ pub struct AgentRun {
     pub title: String,
     pub description: String,
     pub status: TaskStatus,
+    #[serde(default)]
+    pub runtime_status: AgentRunRuntimeStatus,
     #[serde(default)]
     pub priority: TaskPriority,
     #[serde(default)]

--- a/crates/amux-daemon/src/agent/types/tests/part1.rs
+++ b/crates/amux-daemon/src/agent/types/tests/part1.rs
@@ -48,6 +48,56 @@ fn alibaba_coding_plan_switches_to_anthropic_for_anthropic_base_url() {
 }
 
 #[test]
+fn opencode_go_switches_api_type_for_minimax_models() {
+    let provider =
+        get_provider_definition(amux_shared::providers::PROVIDER_ID_OPENCODE_GO)
+            .expect("opencode go");
+    assert_eq!(provider.default_base_url, "https://opencode.ai/zen/go/v1");
+    assert_eq!(provider.default_model, "glm-5.1");
+    assert_eq!(provider.api_type, ApiType::OpenAI);
+    assert_eq!(provider.auth_method, AuthMethod::Bearer);
+    assert!(provider.supports_model_fetch);
+    assert_eq!(provider.default_transport, ApiTransport::ChatCompletions);
+    assert_eq!(provider.models.len(), 9);
+    assert_eq!(provider.models[0].id, "glm-5.1");
+    assert_eq!(provider.models[4].id, "mimo-v2-omni");
+    assert_eq!(provider.models[6].id, "minimax-m2.7");
+    assert_eq!(provider.models[8].id, "qwen3.6-plus");
+    assert_eq!(
+        get_provider_api_type(
+            amux_shared::providers::PROVIDER_ID_OPENCODE_GO,
+            "glm-5.1",
+            "https://opencode.ai/zen/go/v1"
+        ),
+        ApiType::OpenAI
+    );
+    assert_eq!(
+        get_provider_api_type(
+            amux_shared::providers::PROVIDER_ID_OPENCODE_GO,
+            "minimax-m2.7",
+            "https://opencode.ai/zen/go/v1"
+        ),
+        ApiType::Anthropic
+    );
+    assert_eq!(
+        get_provider_api_type(
+            amux_shared::providers::PROVIDER_ID_OPENCODE_GO,
+            "opencode-go/minimax-m2.5",
+            "https://opencode.ai/zen/go/v1"
+        ),
+        ApiType::Anthropic
+    );
+    assert_eq!(
+        get_provider_base_url(
+            amux_shared::providers::PROVIDER_ID_OPENCODE_GO,
+            "minimax-m2.7",
+            "https://opencode.ai/zen/go/v1"
+        ),
+        "https://opencode.ai/zen/go/v1"
+    );
+}
+
+#[test]
 fn default_retry_delay_is_five_seconds() {
     let parsed: AgentConfig = serde_json::from_str("{}").unwrap();
     assert_eq!(parsed.retry_delay_ms, 5_000);

--- a/crates/amux-daemon/src/main.rs
+++ b/crates/amux-daemon/src/main.rs
@@ -62,21 +62,6 @@ async fn daemon_main() -> Result<()> {
 
     tracing::info!("tamux-daemon starting");
 
-    // Restore any persisted state.
-    let state_path = state::default_state_path();
-    tracing::info!(?state_path, "state file location");
-    match state::load_state(&state_path) {
-        Ok(state) => {
-            tracing::info!(
-                previous_sessions = state.previous_sessions.len(),
-                "loaded persisted daemon state"
-            );
-        }
-        Err(error) => {
-            tracing::warn!(error = %error, path = %state_path.display(), "failed to load persisted daemon state");
-        }
-    }
-
     // Start the IPC server (blocks until shutdown signal).
     server::run().await?;
 

--- a/crates/amux-daemon/src/server/post_tests.rs
+++ b/crates/amux-daemon/src/server/post_tests.rs
@@ -54,13 +54,33 @@ pub async fn run() -> Result<()> {
         .context("failed to initialize shared history store")?;
     let history = Arc::new(history);
 
+    let state_path = crate::state::default_state_path();
+    tracing::info!(?state_path, "state file location");
+    let restored_state = match crate::state::load_state(&state_path) {
+        Ok(state) => {
+            tracing::info!(
+                previous_sessions = state.previous_sessions.len(),
+                "loaded persisted daemon state"
+            );
+            state
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, path = %state_path.display(), "failed to load persisted daemon state");
+            crate::state::DaemonState::default()
+        }
+    };
+
     // load_config now takes &HistoryStore
     let agent_config = crate::agent::load_config_from_history(&history)
         .await
         .unwrap_or_default();
 
-    let manager =
-        SessionManager::new_with_history(history.clone(), agent_config.pty_channel_capacity);
+    let manager = SessionManager::new_with_history_and_state(
+        history.clone(),
+        agent_config.pty_channel_capacity,
+        state_path,
+        restored_state,
+    );
     let reaper_manager = manager.clone();
 
     tokio::spawn(async move {

--- a/crates/amux-daemon/src/session_manager.rs
+++ b/crates/amux-daemon/src/session_manager.rs
@@ -24,6 +24,7 @@ mod session_ops;
 /// Central session registry — the source of truth for all running terminals.
 pub struct SessionManager {
     sessions: RwLock<HashMap<SessionId, Arc<Mutex<PtySession>>>>,
+    restored_sessions: RwLock<Vec<SavedSession>>,
     state_path: std::path::PathBuf,
     history: Arc<HistoryStore>,
     snapshots: SnapshotStore,
@@ -91,10 +92,25 @@ impl SessionManager {
     }
 
     pub fn new_with_history(history: Arc<HistoryStore>, pty_channel_capacity: usize) -> Arc<Self> {
+        Self::new_with_history_and_state(
+            history,
+            pty_channel_capacity,
+            crate::state::default_state_path(),
+            DaemonState::default(),
+        )
+    }
+
+    pub fn new_with_history_and_state(
+        history: Arc<HistoryStore>,
+        pty_channel_capacity: usize,
+        state_path: std::path::PathBuf,
+        restored_state: DaemonState,
+    ) -> Arc<Self> {
         let snapshots = SnapshotStore::new_with_history((*history).clone());
         Arc::new(Self {
             sessions: RwLock::new(HashMap::new()),
-            state_path: crate::state::default_state_path(),
+            restored_sessions: RwLock::new(restored_state.previous_sessions),
+            state_path,
             history,
             snapshots,
             pending_approvals: RwLock::new(HashMap::new()),

--- a/crates/amux-daemon/src/session_manager/session_ops.rs
+++ b/crates/amux-daemon/src/session_manager/session_ops.rs
@@ -148,18 +148,20 @@ async fn queue_with_snapshot(
     request: ManagedCommandRequest,
     snapshot_reason: &str,
 ) -> Result<(usize, Option<amux_protocol::SnapshotInfo>)> {
-    let snapshot = {
-        let session = session.lock().await;
-        snapshots
-            .create_snapshot(
-                workspace_id,
-                Some(session_id),
-                request.cwd.as_deref().or_else(|| session.cwd()),
-                Some(&request.command),
-                snapshot_reason,
-            )
-            .await?
+    let snapshot_cwd = if let Some(cwd) = request.cwd.as_deref() {
+        Some(cwd.to_owned())
+    } else {
+        session.lock().await.cwd().map(ToOwned::to_owned)
     };
+    let snapshot = snapshots
+        .create_snapshot(
+            workspace_id,
+            Some(session_id),
+            snapshot_cwd.as_deref(),
+            Some(&request.command),
+            snapshot_reason,
+        )
+        .await?;
     let position =
         session
             .lock()
@@ -403,6 +405,7 @@ impl SessionManager {
             .collect();
 
         let mut infos = Vec::with_capacity(sessions.len());
+        let mut live_ids = std::collections::HashSet::with_capacity(sessions.len());
         for (id, session) in sessions {
             let s = session.lock().await;
             if s.is_dead() {
@@ -427,6 +430,38 @@ impl SessionManager {
                 exit_code: None,
                 is_alive: !s.is_dead(),
                 active_command: s.active_command(),
+            });
+            live_ids.insert(id);
+        }
+
+        let restored_sessions = self.restored_sessions.read().await.clone();
+        for session in restored_sessions {
+            let Ok(id) = session.id.parse() else {
+                tracing::warn!(session_id = %session.id, "skipping restored session with invalid id");
+                continue;
+            };
+
+            if live_ids.contains(&id) {
+                continue;
+            }
+
+            if let Some(filter) = workspace_filter {
+                if session.workspace_id.as_deref() != Some(filter) {
+                    continue;
+                }
+            }
+
+            infos.push(SessionInfo {
+                id,
+                title: None,
+                cwd: session.cwd,
+                cols: session.cols,
+                rows: session.rows,
+                created_at: 0,
+                workspace_id: session.workspace_id,
+                exit_code: None,
+                is_alive: false,
+                active_command: None,
             });
         }
         infos

--- a/crates/amux-daemon/src/session_manager/tests.rs
+++ b/crates/amux-daemon/src/session_manager/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::sync::Arc;
 
 #[cfg(unix)]
 #[tokio::test]
@@ -39,6 +40,42 @@ async fn list_omits_dead_sessions_and_managed_execution_rejects_them() {
         .expect_err("dead sessions must be rejected for managed execution");
 
     assert!(error.to_string().contains("not alive"));
+}
+
+#[tokio::test]
+async fn list_includes_restored_stale_sessions() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let history = Arc::new(
+        HistoryStore::new_test_store(root.path())
+            .await
+            .expect("test history store initialization failed"),
+    );
+    let stale_id = uuid::Uuid::new_v4();
+    let manager = SessionManager::new_with_history_and_state(
+        history,
+        256,
+        root.path().join("daemon-state.json"),
+        DaemonState {
+            previous_sessions: vec![SavedSession {
+                id: stale_id.to_string(),
+                shell: Some("/bin/zsh".to_string()),
+                cwd: Some("/tmp/stale".to_string()),
+                workspace_id: Some("workspace-stale".to_string()),
+                cols: 100,
+                rows: 30,
+            }],
+        },
+    );
+
+    let sessions = manager.list().await;
+    assert_eq!(sessions.len(), 1);
+    let session = &sessions[0];
+    assert_eq!(session.id, stale_id);
+    assert_eq!(session.cwd.as_deref(), Some("/tmp/stale"));
+    assert_eq!(session.workspace_id.as_deref(), Some("workspace-stale"));
+    assert!(!session.is_alive, "restored session should be marked stale");
+    assert_eq!(session.cols, 100);
+    assert_eq!(session.rows, 30);
 }
 
 #[cfg(unix)]

--- a/crates/amux-daemon/src/state.rs
+++ b/crates/amux-daemon/src/state.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -13,7 +13,7 @@ pub struct DaemonState {
     pub previous_sessions: Vec<SavedSession>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedSession {
     pub id: String,
     pub shell: Option<String>,
@@ -23,17 +23,40 @@ pub struct SavedSession {
     pub rows: u16,
 }
 
+fn legacy_state_path() -> PathBuf {
+    let base = dirs::data_local_dir().unwrap_or_else(|| PathBuf::from("."));
+    base.join("amux").join("daemon-state.json")
+}
+
+fn canonical_state_path() -> PathBuf {
+    let base = amux_protocol::ensure_amux_data_dir().unwrap_or_else(|_| PathBuf::from("."));
+    base.join("daemon-state.json")
+}
+
+fn migrate_legacy_state_file(target: &Path) {
+    let legacy = legacy_state_path();
+    if target.exists() || !legacy.exists() {
+        return;
+    }
+
+    if let Some(parent) = target.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let _ = std::fs::rename(&legacy, target);
+}
+
 /// Default path for the state file.
 pub fn default_state_path() -> PathBuf {
-    let base = dirs::data_local_dir().unwrap_or_else(|| PathBuf::from("."));
-    let dir = base.join("amux");
-    let _ = std::fs::create_dir_all(&dir);
-    dir.join("daemon-state.json")
+    let path = canonical_state_path();
+    migrate_legacy_state_file(&path);
+    path
 }
 
 /// Load state from disk.
 #[allow(dead_code)]
 pub fn load_state(path: &std::path::Path) -> Result<DaemonState> {
+    migrate_legacy_state_file(path);
     if path.exists() {
         let data = std::fs::read_to_string(path)?;
         let state: DaemonState = serde_json::from_str(&data)?;
@@ -46,7 +69,47 @@ pub fn load_state(path: &std::path::Path) -> Result<DaemonState> {
 /// Save state to disk.
 #[allow(dead_code)]
 pub fn save_state(path: &std::path::Path, state: &DaemonState) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     let data = serde_json::to_string_pretty(state)?;
     std::fs::write(path, data)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_state_creates_parent_directories() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("nested").join("daemon-state.json");
+
+        save_state(&path, &DaemonState::default()).expect("save state");
+
+        assert!(path.exists(), "state file should be written");
+    }
+
+    #[test]
+    fn load_state_reads_existing_file() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("daemon-state.json");
+        let state = DaemonState {
+            previous_sessions: vec![SavedSession {
+                id: "session-1".to_string(),
+                shell: Some("/bin/zsh".to_string()),
+                cwd: Some("/tmp".to_string()),
+                workspace_id: Some("workspace-a".to_string()),
+                cols: 120,
+                rows: 40,
+            }],
+        };
+
+        save_state(&path, &state).expect("save state");
+
+        let loaded = load_state(&path).expect("load state");
+        assert_eq!(loaded.previous_sessions.len(), 1);
+        assert_eq!(loaded.previous_sessions[0].id, "session-1");
+    }
 }

--- a/crates/amux-shared/src/providers.rs
+++ b/crates/amux-shared/src/providers.rs
@@ -24,6 +24,7 @@ pub const PROVIDER_ID_NOUS_PORTAL: &str = "nous-portal";
 pub const PROVIDER_ID_OLLAMA: &str = "ollama";
 pub const PROVIDER_ID_OPENAI: &str = "openai";
 pub const PROVIDER_ID_CHATGPT_SUBSCRIPTION: &str = "chatgpt_subscription";
+pub const PROVIDER_ID_OPENCODE_GO: &str = "opencode-go";
 pub const PROVIDER_ID_OPENCODE_ZEN: &str = "opencode-zen";
 pub const PROVIDER_ID_OPENROUTER: &str = "openrouter";
 pub const PROVIDER_ID_QWEN: &str = "qwen";
@@ -62,6 +63,9 @@ pub const NOUS_PORTAL_PROVIDER: ProviderRef = ProviderRef {
 };
 pub const OPENAI_PROVIDER: ProviderRef = ProviderRef {
     id: PROVIDER_ID_OPENAI,
+};
+pub const OPENCODE_GO_PROVIDER: ProviderRef = ProviderRef {
+    id: PROVIDER_ID_OPENCODE_GO,
 };
 pub const OPENCODE_ZEN_PROVIDER: ProviderRef = ProviderRef {
     id: PROVIDER_ID_OPENCODE_ZEN,

--- a/crates/amux-tui/src/providers.rs
+++ b/crates/amux-tui/src/providers.rs
@@ -375,6 +375,17 @@ pub const PROVIDERS: &[ProviderDef] = &[
         native_base_url: None,
     },
     ProviderDef {
+        id: PROVIDER_ID_OPENCODE_GO,
+        name: "OpenCode Go",
+        default_base_url: "https://opencode.ai/zen/go/v1",
+        default_model: "glm-5.1",
+        supported_transports: CHAT_ONLY_TRANSPORTS,
+        default_transport: "chat_completions",
+        supported_auth_sources: API_KEY_ONLY_AUTH_SOURCES,
+        default_auth_source: "api_key",
+        native_base_url: None,
+    },
+    ProviderDef {
         id: PROVIDER_ID_OPENCODE_ZEN,
         name: "OpenCode Zen",
         default_base_url: "https://opencode.ai/zen/v1",
@@ -421,11 +432,20 @@ pub fn default_transport_for(provider: &str) -> &'static str {
         .unwrap_or("chat_completions")
 }
 
+fn opencode_go_uses_anthropic_messages(model: &str) -> bool {
+    let normalized = model.trim().to_ascii_lowercase();
+    let normalized = normalized
+        .strip_prefix("opencode-go/")
+        .unwrap_or(normalized.as_str());
+    normalized.starts_with("minimax-m2.")
+}
+
 pub fn uses_fixed_anthropic_messages(provider: &str, model: &str) -> bool {
     matches!(
         provider,
         PROVIDER_ID_ANTHROPIC | PROVIDER_ID_MINIMAX | PROVIDER_ID_MINIMAX_CODING_PLAN
-    ) || (provider == PROVIDER_ID_OPENCODE_ZEN && model.starts_with("claude"))
+    ) || (provider == PROVIDER_ID_OPENCODE_GO && opencode_go_uses_anthropic_messages(model))
+        || (provider == PROVIDER_ID_OPENCODE_ZEN && model.starts_with("claude"))
 }
 
 pub fn supported_auth_sources_for(provider: &str) -> &'static [&'static str] {

--- a/crates/amux-tui/src/providers/catalog.rs
+++ b/crates/amux-tui/src/providers/catalog.rs
@@ -241,6 +241,17 @@ pub const PROVIDERS: &[ProviderDef] = &[
         native_base_url: None,
     },
     ProviderDef {
+        id: PROVIDER_ID_OPENCODE_GO,
+        name: "OpenCode Go",
+        default_base_url: "https://opencode.ai/zen/go/v1",
+        default_model: "glm-5.1",
+        supported_transports: CHAT_ONLY_TRANSPORTS,
+        default_transport: "chat_completions",
+        supported_auth_sources: API_KEY_ONLY_AUTH_SOURCES,
+        default_auth_source: "api_key",
+        native_base_url: None,
+    },
+    ProviderDef {
         id: PROVIDER_ID_OPENCODE_ZEN,
         name: "OpenCode Zen",
         default_base_url: "https://opencode.ai/zen/v1",

--- a/crates/amux-tui/src/providers/model_catalog.rs
+++ b/crates/amux-tui/src/providers/model_catalog.rs
@@ -187,6 +187,17 @@ pub(super) fn known_models_for_provider_auth(
             ("mimo-v2-pro", "MiMo V2 Pro", 1_000_000),
             ("mimo-v2-omni", "MiMo V2 Omni", 256_000),
         ],
+        PROVIDER_ID_OPENCODE_GO => &[
+            ("glm-5.1", "GLM-5.1", 204_800),
+            ("glm-5", "GLM-5", 202_752),
+            ("kimi-k2.5", "Kimi K2.5", 262_144),
+            ("mimo-v2-pro", "MiMo V2 Pro", 1_000_000),
+            ("mimo-v2-omni", "MiMo V2 Omni", 256_000),
+            ("minimax-m2.5", "MiniMax M2.5", 205_000),
+            ("minimax-m2.7", "MiniMax M2.7", 205_000),
+            ("qwen3.5-plus", "Qwen3.5 Plus", 983_616),
+            ("qwen3.6-plus", "Qwen3.6 Plus", 983_616),
+        ],
         PROVIDER_ID_NOUS_PORTAL => &[
             ("nousresearch/hermes-4-70b", "Nous: Hermes 4 70B", 131_072),
             ("nousresearch/hermes-4-405b", "Nous: Hermes 4 405B", 131_072),

--- a/crates/amux-tui/src/providers/tests.rs
+++ b/crates/amux-tui/src/providers/tests.rs
@@ -2,12 +2,13 @@ use super::*;
 use crate::providers::context::is_known_default_url;
 use amux_shared::providers::{
     MINIMAX_PROVIDER, PROVIDER_ID_ALIBABA_CODING_PLAN, PROVIDER_ID_ANTHROPIC, PROVIDER_ID_ARCEE,
-    PROVIDER_ID_GITHUB_COPILOT, PROVIDER_ID_NVIDIA, PROVIDER_ID_OPENAI, QWEN_PROVIDER,
+    PROVIDER_ID_GITHUB_COPILOT, PROVIDER_ID_NVIDIA, PROVIDER_ID_OPENAI, PROVIDER_ID_OPENCODE_GO,
+    QWEN_PROVIDER,
 };
 
 #[test]
-fn provider_count_is_26() {
-    assert_eq!(PROVIDERS.len(), 26);
+fn provider_count_is_28() {
+    assert_eq!(PROVIDERS.len(), 28);
 }
 
 #[test]
@@ -55,6 +56,18 @@ fn anthropic_message_providers_are_detected() {
         PROVIDER_ID_ALIBABA_CODING_PLAN,
         "qwen3.6-plus"
     ));
+    assert!(uses_fixed_anthropic_messages(
+        PROVIDER_ID_OPENCODE_GO,
+        "minimax-m2.7"
+    ));
+    assert!(uses_fixed_anthropic_messages(
+        PROVIDER_ID_OPENCODE_GO,
+        "opencode-go/minimax-m2.5"
+    ));
+    assert!(!uses_fixed_anthropic_messages(
+        PROVIDER_ID_OPENCODE_GO,
+        "glm-5.1"
+    ));
 }
 
 #[test]
@@ -82,6 +95,16 @@ fn known_models_openai_chatgpt_subscription_is_restricted() {
     assert!(models.iter().any(|m| m.id == "gpt-5.4"));
     assert!(!models.iter().any(|m| m.id == "gpt-4o"));
     assert!(!models.iter().any(|m| m.id == "o3"));
+}
+
+#[test]
+fn known_models_opencode_go_include_open_and_minimax_tiers() {
+    let models = known_models_for_provider(PROVIDER_ID_OPENCODE_GO);
+    assert_eq!(models.len(), 9);
+    assert!(models.iter().any(|model| model.id == "glm-5.1"));
+    assert!(models.iter().any(|model| model.id == "mimo-v2-pro"));
+    assert!(models.iter().any(|model| model.id == "minimax-m2.7"));
+    assert!(models.iter().any(|model| model.id == "qwen3.6-plus"));
 }
 
 #[test]

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -45,6 +45,7 @@ Data directory: `~/.tamux/` on Unix, `%LOCALAPPDATA%\tamux\` on Windows. Existin
 | MiniMax | `minimax` | MiniMax-M1-80k | api.minimax.io |
 | MiniMax Coding Plan | `minimax-coding-plan` | MiniMax-M2.7 | api.minimax.io/anthropic |
 | Alibaba Coding Plan | `alibaba-coding-plan` | qwen3-coder | coding-intl.dashscope.aliyuncs.com |
+| OpenCode Go | `opencode-go` | glm-5.1 | opencode.ai/zen/go |
 | OpenCode Zen | `opencode-zen` | claude-sonnet-4-5 | opencode.ai/zen |
 | Custom | `custom` | user-defined | user-defined |
 
@@ -53,6 +54,7 @@ Data directory: `~/.tamux/` on Unix, `%LOCALAPPDATA%\tamux\` on Windows. Existin
 - Most providers use OpenAI-compatible `/chat/completions` endpoints
 - Anthropic, MiniMax, and MiniMax Coding Plan use the Anthropic Messages API at `/v1/messages`
 - Alibaba Coding Plan supports both OpenAI-compatible `/v1` and Anthropic-compatible `/apps/anthropic`, auto-selected by model name
+- OpenCode Go uses Anthropic Messages for `minimax-m2.x` models and OpenAI-compatible chat completions for the rest
 - OpenCode Zen auto-selects Anthropic format for Claude models and OpenAI-compatible format for others
 
 Switch providers at any time from the Settings panel. Each provider's base URL, model, and API key are independently configurable, and models can be selected from a searchable list or entered manually.

--- a/frontend/electron/main/plugins.cjs
+++ b/frontend/electron/main/plugins.cjs
@@ -3,6 +3,10 @@ const path = require('path');
 
 const { ensureTamuxDataDir, readJsonFile } = require('./app-data.cjs');
 
+function unsafeRendererPluginsEnabled(env = process.env) {
+    return String(env.TAMUX_ENABLE_UNSAFE_RENDERER_PLUGINS || '').trim() === '1';
+}
+
 function getPluginsRootDir() {
     const pluginsDir = path.join(ensureTamuxDataDir(), 'plugins');
     fs.mkdirSync(pluginsDir, { recursive: true });
@@ -62,6 +66,17 @@ function loadInstalledPluginScripts() {
                 };
             }
 
+            if (!unsafeRendererPluginsEnabled()) {
+                return {
+                    packageName: entry.packageName,
+                    pluginName: entry.pluginName,
+                    entryPath: entry.entryPath,
+                    format: entry.format,
+                    status: 'skipped',
+                    error: 'Renderer plugin loading is disabled by default. Set TAMUX_ENABLE_UNSAFE_RENDERER_PLUGINS=1 to opt in.',
+                };
+            }
+
             const resolvedEntryPath = resolveInstalledPluginEntryPath(entry.entryPath);
             if (!fs.existsSync(resolvedEntryPath) || !fs.statSync(resolvedEntryPath).isFile()) {
                 return {
@@ -99,4 +114,5 @@ module.exports = {
     getPluginsRootDir,
     listInstalledPlugins,
     loadInstalledPluginScripts,
+    unsafeRendererPluginsEnabled,
 };

--- a/frontend/electron/main/window-runtime.cjs
+++ b/frontend/electron/main/window-runtime.cjs
@@ -84,6 +84,7 @@ function createWindowRuntime(options) {
                 preload: path.join(options.electronDir, 'preload.cjs'),
                 nodeIntegration: false,
                 contextIsolation: true,
+                sandbox: true,
                 webviewTag: true,
             },
             title: 'tamux',

--- a/frontend/electron/plugins-security.test.cjs
+++ b/frontend/electron/plugins-security.test.cjs
@@ -1,0 +1,27 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { unsafeRendererPluginsEnabled } = require("./main/plugins.cjs");
+
+test("renderer plugin loading stays opt-in", () => {
+  assert.equal(unsafeRendererPluginsEnabled({}), false);
+  assert.equal(
+    unsafeRendererPluginsEnabled({ TAMUX_ENABLE_UNSAFE_RENDERER_PLUGINS: "0" }),
+    false,
+  );
+  assert.equal(
+    unsafeRendererPluginsEnabled({ TAMUX_ENABLE_UNSAFE_RENDERER_PLUGINS: "1" }),
+    true,
+  );
+});
+
+test("browser window keeps Electron sandbox enabled", () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, "main", "window-runtime.cjs"),
+    "utf8",
+  );
+
+  assert.match(source, /sandbox:\s*true/);
+});

--- a/frontend/src/CDUIApp.tsx
+++ b/frontend/src/CDUIApp.tsx
@@ -75,11 +75,11 @@ const CDUIApp = () => {
       try {
         const pluginResults = await (window.tamux ?? window.amux)?.loadInstalledPlugins?.();
         if (Array.isArray(pluginResults)) {
-          const failedOrSkipped = pluginResults.filter(
-            (result) => result && (result.status === "error" || result.status === "skipped"),
+          const failed = pluginResults.filter(
+            (result) => result && result.status === "error",
           );
-          if (failedOrSkipped.length > 0) {
-            console.warn("Some installed plugins failed to load", failedOrSkipped);
+          if (failed.length > 0) {
+            console.warn("Some installed plugins failed to load", failed);
           }
         }
       } catch (pluginLoadError) {

--- a/frontend/src/components/StatusChip.tsx
+++ b/frontend/src/components/StatusChip.tsx
@@ -1,0 +1,46 @@
+import type { CSSProperties } from "react";
+import type { StatusChipTone } from "@/lib/statusChips";
+
+type StatusChipProps = {
+  icon?: string;
+  label: string;
+  tone?: StatusChipTone;
+  style?: CSSProperties;
+  title?: string;
+};
+
+function chipToneClassName(tone: StatusChipTone): string {
+  switch (tone) {
+    case "accent":
+      return "amux-chip amux-chip--accent";
+    case "approval":
+      return "amux-chip amux-chip--approval";
+    case "warning":
+      return "amux-chip amux-chip--warning";
+    case "success":
+      return "amux-chip amux-chip--success";
+    case "danger":
+      return "amux-chip amux-chip--danger";
+    default:
+      return "amux-chip";
+  }
+}
+
+export function StatusChip({
+  icon,
+  label,
+  tone = "neutral",
+  style,
+  title,
+}: StatusChipProps) {
+  return (
+    <span
+      className={chipToneClassName(tone)}
+      style={{ fontSize: 11, padding: "2px 8px", ...style }}
+      title={title}
+    >
+      {icon ? <span aria-hidden="true">{icon}</span> : null}
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/TaskTray.tsx
+++ b/frontend/src/components/TaskTray.tsx
@@ -1,9 +1,13 @@
+import { StatusChip } from "@/components/StatusChip";
 import { useEffect, useRef, useMemo, useState, type CSSProperties, type Dispatch, type SetStateAction } from "react";
 import { getBridge } from "@/lib/bridge";
 import {
     fetchAgentTasks,
     formatTaskStatus,
     formatTaskTimestamp,
+    getTaskStatusChip,
+    getTaskStatusReason,
+    getTaskStatusReasonChip,
     isTaskActive,
     taskStatusColor,
     type AgentQueueTask,
@@ -161,6 +165,7 @@ export function TaskTrayButton() {
                                 tasks.map((task) => {
                                     const selected = task.id === selectedTask?.id;
                                     const color = taskStatusColor(task.status);
+                                    const statusChip = getTaskStatusChip(task);
                                     return (
                                         <button
                                             key={task.id}
@@ -190,8 +195,8 @@ export function TaskTrayButton() {
                                                     <div style={{ fontSize: "var(--text-sm)", fontWeight: 600, color: "var(--text-primary)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
                                                         {task.title}
                                                     </div>
-                                                    <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                                                        <span style={{ color }}>{formatTaskStatus(task)}</span>
+                                                    <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
+                                                        <StatusChip icon={statusChip.icon} label={statusChip.label} tone={statusChip.tone} />
                                                         <span>{task.priority}</span>
                                                         <span>{formatTaskTimestamp(task.created_at)}</span>
                                                     </div>
@@ -216,7 +221,9 @@ export function TaskTrayButton() {
 }
 
 function TaskDetail({ task, onCancelled }: { task: AgentQueueTask; onCancelled: () => void }) {
-    const color = taskStatusColor(task.status);
+    const statusChip = getTaskStatusChip(task);
+    const statusReason = getTaskStatusReason(task);
+    const reasonChip = getTaskStatusReasonChip(task);
     const amux = getBridge();
     const canCancel = task.status === "queued" || task.status === "in_progress" || task.status === "blocked" || task.status === "failed_analyzing";
     const logs = [...(task.logs ?? [])].slice(-6).reverse();
@@ -232,9 +239,12 @@ function TaskDetail({ task, onCancelled }: { task: AgentQueueTask; onCancelled: 
             <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-3)", alignItems: "flex-start" }}>
                 <div style={{ minWidth: 0 }}>
                     <div style={{ fontSize: "var(--text-base)", fontWeight: 700, color: "var(--text-primary)" }}>{task.title}</div>
-                    <div style={{ marginTop: 4, fontSize: "var(--text-xs)", color }}>
-                        {formatTaskStatus(task)}
-                        {typeof task.retry_count === "number" && typeof task.max_retries === "number" ? ` · retry ${task.retry_count}/${task.max_retries}` : ""}
+                    <div style={{ marginTop: 4, fontSize: "var(--text-xs)", color: "var(--text-muted)", display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                        <StatusChip icon={statusChip.icon} label={statusChip.label} tone={statusChip.tone} />
+                        <span>
+                            {formatTaskStatus(task)}
+                            {typeof task.retry_count === "number" && typeof task.max_retries === "number" ? ` · retry ${task.retry_count}/${task.max_retries}` : ""}
+                        </span>
                     </div>
                 </div>
                 {canCancel && (
@@ -247,8 +257,13 @@ function TaskDetail({ task, onCancelled }: { task: AgentQueueTask; onCancelled: 
             <div style={detailBlockStyle}>{task.description}</div>
 
             {task.command && <div style={detailBlockStyle}>Command: {task.command}</div>}
-            {task.blocked_reason && <div style={detailBlockStyle}>Gate: {task.blocked_reason}</div>}
-            {task.last_error && <div style={{ ...detailBlockStyle, color: "var(--danger)" }}>Last error: {task.last_error}</div>}
+            {statusReason && (
+                <div style={{ ...detailBlockStyle, display: "flex", alignItems: "flex-start", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                    {reasonChip ? <StatusChip icon={reasonChip.icon} label={reasonChip.label} tone={reasonChip.tone} style={{ fontSize: 10, padding: "1px 6px" }} /> : null}
+                    <span>{statusReason}</span>
+                </div>
+            )}
+            {task.last_error && !statusReason && <div style={{ ...detailBlockStyle, color: "var(--danger)" }}>Last error: {task.last_error}</div>}
 
             <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: "var(--space-2)", marginTop: "var(--space-3)" }}>
                 <InfoPill label="Created" value={formatTaskTimestamp(task.created_at)} />

--- a/frontend/src/components/agent-chat-panel/SpawnedAgentsPanel.test.tsx
+++ b/frontend/src/components/agent-chat-panel/SpawnedAgentsPanel.test.tsx
@@ -13,6 +13,9 @@ function makeRun(overrides: Partial<AgentRun> = {}): AgentRun {
     title: "Root Agent",
     description: "Inspect the spawned agent",
     status: "in_progress",
+    runtime_status: {
+      kind: "running",
+    },
     priority: "normal",
     progress: 50,
     created_at: 1,
@@ -48,6 +51,10 @@ describe("SpawnedAgentsPanel", () => {
       thread_id: null,
       session_id: "session-waiting",
       status: "queued",
+      runtime_status: {
+        kind: "waiting_for_dependencies",
+        reason: "waiting for dependencies: task-anchor",
+      },
       parent_task_id: "task-anchor",
       parent_thread_id: "daemon-root",
       created_at: 3,
@@ -95,6 +102,8 @@ describe("SpawnedAgentsPanel", () => {
     expect(html).toContain("Root Agent");
     expect(html).toContain("Spawned Child");
     expect(html).toContain("Waiting Child");
+    expect(html).toContain("Waiting for dependencies");
+    expect(html).toContain("waiting for dependencies: task-anchor");
     expect(html).toContain("claude-code");
     expect(html).toContain("session-child");
     expect(html).toContain('aria-label="Open chat for Waiting Child"');

--- a/frontend/src/components/agent-chat-panel/SpawnedAgentsPanel.test.tsx
+++ b/frontend/src/components/agent-chat-panel/SpawnedAgentsPanel.test.tsx
@@ -102,8 +102,8 @@ describe("SpawnedAgentsPanel", () => {
     expect(html).toContain("Root Agent");
     expect(html).toContain("Spawned Child");
     expect(html).toContain("Waiting Child");
-    expect(html).toContain("Waiting for dependencies");
-    expect(html).toContain("waiting for dependencies: task-anchor");
+    expect(html).toContain("⇢ Deps");
+    expect(html).toContain("⇢ Depends on · Dependencies: task-anchor");
     expect(html).toContain("claude-code");
     expect(html).toContain("session-child");
     expect(html).toContain('aria-label="Open chat for Waiting Child"');

--- a/frontend/src/components/agent-chat-panel/SpawnedAgentsPanel.tsx
+++ b/frontend/src/components/agent-chat-panel/SpawnedAgentsPanel.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { AgentRun } from "@/lib/agentRuns";
 import {
   formatRunStatus,
+  getRunStatusReason,
   runStatusColor,
 } from "@/lib/agentRuns";
 import type {
@@ -63,6 +64,7 @@ export function SpawnedAgentNode({
   );
   const canOpen = canOpenSpawnedThread(node.item);
   const meta = renderNodeMeta(node.item);
+  const statusReason = getRunStatusReason(node.item);
 
   return (
     <div
@@ -106,7 +108,7 @@ export function SpawnedAgentNode({
                 borderRadius: 999,
                 padding: "2px 8px",
                 border: "1px solid color-mix(in srgb, currentColor 35%, transparent)",
-                color: runStatusColor(node.item.status),
+                color: runStatusColor(node.item),
                 background: "color-mix(in srgb, currentColor 10%, transparent)",
               }}
             >
@@ -129,6 +131,22 @@ export function SpawnedAgentNode({
             )}
           </div>
         </div>
+
+        {statusReason && (
+          <div
+            style={{
+              fontSize: "var(--text-xs)",
+              color: "var(--text-secondary)",
+              background: "color-mix(in srgb, var(--bg-primary) 72%, transparent)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius-md)",
+              padding: "6px 8px",
+              wordBreak: "break-word",
+            }}
+          >
+            {statusReason}
+          </div>
+        )}
 
         <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-2)", alignItems: "center", flexWrap: "wrap" }}>
           <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>

--- a/frontend/src/components/agent-chat-panel/SpawnedAgentsPanel.tsx
+++ b/frontend/src/components/agent-chat-panel/SpawnedAgentsPanel.tsx
@@ -1,9 +1,10 @@
+import { StatusChip } from "@/components/StatusChip";
 import type { ReactNode } from "react";
 import type { AgentRun } from "@/lib/agentRuns";
 import {
-  formatRunStatus,
+  getRunStatusChip,
   getRunStatusReason,
-  runStatusColor,
+  getRunStatusReasonChip,
 } from "@/lib/agentRuns";
 import type {
   SpawnedAgentTree,
@@ -65,6 +66,8 @@ export function SpawnedAgentNode({
   const canOpen = canOpenSpawnedThread(node.item);
   const meta = renderNodeMeta(node.item);
   const statusReason = getRunStatusReason(node.item);
+  const statusChip = getRunStatusChip(node.item);
+  const reasonChip = getRunStatusReasonChip(node.item);
 
   return (
     <div
@@ -101,33 +104,18 @@ export function SpawnedAgentNode({
             )}
           </div>
           <div style={{ display: "flex", gap: "var(--space-1)", flexWrap: "wrap", justifyContent: "flex-end" }}>
-            <span
-              style={{
-                fontSize: 11,
-                fontWeight: 700,
-                borderRadius: 999,
-                padding: "2px 8px",
-                border: "1px solid color-mix(in srgb, currentColor 35%, transparent)",
-                color: runStatusColor(node.item),
-                background: "color-mix(in srgb, currentColor 10%, transparent)",
-              }}
-            >
-              {formatRunStatus(node.item)}
-            </span>
+            <StatusChip
+              icon={statusChip.icon}
+              label={statusChip.label}
+              tone={statusChip.tone}
+            />
             {isSelected && (
-              <span
-                style={{
-                  fontSize: 11,
-                  fontWeight: 700,
-                  borderRadius: 999,
-                  padding: "2px 8px",
-                  border: "1px solid var(--accent-soft)",
-                  color: "var(--accent)",
-                  background: "rgba(94, 231, 223, 0.12)",
-                }}
-              >
-                Current
-              </span>
+              <StatusChip
+                icon="•"
+                label="Current"
+                tone="accent"
+                style={{ borderColor: "var(--accent-soft)" }}
+              />
             )}
           </div>
         </div>
@@ -142,9 +130,21 @@ export function SpawnedAgentNode({
               borderRadius: "var(--radius-md)",
               padding: "6px 8px",
               wordBreak: "break-word",
+              display: "flex",
+              alignItems: "flex-start",
+              gap: "var(--space-2)",
+              flexWrap: "wrap",
             }}
           >
-            {statusReason}
+            {reasonChip ? (
+              <StatusChip
+                icon={reasonChip.icon}
+                label={reasonChip.label}
+                tone={reasonChip.tone}
+                style={{ fontSize: 10, padding: "1px 6px" }}
+              />
+            ) : null}
+            <span>{statusReason}</span>
           </div>
         )}
 

--- a/frontend/src/components/agent-chat-panel/SubagentsView.tsx
+++ b/frontend/src/components/agent-chat-panel/SubagentsView.tsx
@@ -1,8 +1,9 @@
+import { StatusChip } from "@/components/StatusChip";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { getBridge } from "@/lib/bridge";
 import { resolveReactChatHistoryMessageLimit } from "@/lib/chatHistoryPageSize";
 import { allLeafIds, findLeaf } from "../../lib/bspTree";
-import { fetchAgentRuns, formatRunStatus, formatRunTimestamp, getRunStatusReason, isRunActive, isSubagentRun, runStatusColor, type AgentRun } from "../../lib/agentRuns";
+import { fetchAgentRuns, formatRunStatus, formatRunTimestamp, getRunStatusChip, getRunStatusReason, getRunStatusReasonChip, isRunActive, isSubagentRun, runStatusColor, type AgentRun } from "../../lib/agentRuns";
 import { fetchThreadTodos } from "../../lib/agentTodos";
 import { buildHydratedRemoteMessage, type RemoteAgentMessageRecord, useAgentStore } from "../../lib/agentStore";
 import type { Workspace } from "../../lib/types";
@@ -338,6 +339,8 @@ export function SubagentsView({ onOpenThreadView, onOpenTasksView }: SubagentsVi
                                 {group.items.map((run) => {
                                     const location = findTaskWorkspaceLocation(workspaces, run.session_id);
                                     const statusReason = getRunStatusReason(run);
+                                    const statusChip = getRunStatusChip(run);
+                                    const reasonChip = getRunStatusReasonChip(run);
                                     return (
                                         <div
                                             key={run.id}
@@ -351,9 +354,17 @@ export function SubagentsView({ onOpenThreadView, onOpenTasksView }: SubagentsVi
                                             <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "var(--space-3)", flexWrap: "wrap" }}>
                                                 <div style={{ minWidth: 0, flex: 1 }}>
                                                     <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, color: "var(--text-primary)" }}>{run.title}</div>
-                                                    <div style={{ fontSize: "var(--text-xs)", color: "var(--text-secondary)", marginTop: 4 }}>
-                                                        {formatRunStatus(run)} · runtime {run.runtime ?? "daemon"} · {formatRunTimestamp(run.created_at)}
-                                                        {run.classification ? ` · ${run.classification}` : ""}
+                                                    <div style={{ fontSize: "var(--text-xs)", color: "var(--text-secondary)", marginTop: 4, display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                                                        <StatusChip
+                                                            icon={statusChip.icon}
+                                                            label={statusChip.label}
+                                                            tone={statusChip.tone}
+                                                            style={{ fontSize: 10, padding: "2px 6px" }}
+                                                        />
+                                                        <span>
+                                                            {formatRunStatus(run)} · runtime {run.runtime ?? "daemon"} · {formatRunTimestamp(run.created_at)}
+                                                            {run.classification ? ` · ${run.classification}` : ""}
+                                                        </span>
                                                     </div>
                                                     <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: "var(--space-2)" }}>
                                                         {run.description}
@@ -369,9 +380,21 @@ export function SubagentsView({ onOpenThreadView, onOpenTasksView }: SubagentsVi
                                                                 border: "1px solid var(--border)",
                                                                 background: "color-mix(in srgb, var(--bg-primary) 72%, transparent)",
                                                                 wordBreak: "break-word",
+                                                                display: "flex",
+                                                                alignItems: "flex-start",
+                                                                gap: "var(--space-2)",
+                                                                flexWrap: "wrap",
                                                             }}
                                                         >
-                                                            {statusReason}
+                                                            {reasonChip ? (
+                                                                <StatusChip
+                                                                    icon={reasonChip.icon}
+                                                                    label={reasonChip.label}
+                                                                    tone={reasonChip.tone}
+                                                                    style={{ fontSize: 10, padding: "1px 6px" }}
+                                                                />
+                                                            ) : null}
+                                                            <span>{statusReason}</span>
                                                         </div>
                                                     )}
                                                     <div style={{ fontSize: "var(--text-xs)", color: "var(--text-secondary)", marginTop: "var(--space-2)" }}>

--- a/frontend/src/components/agent-chat-panel/SubagentsView.tsx
+++ b/frontend/src/components/agent-chat-panel/SubagentsView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { getBridge } from "@/lib/bridge";
 import { resolveReactChatHistoryMessageLimit } from "@/lib/chatHistoryPageSize";
 import { allLeafIds, findLeaf } from "../../lib/bspTree";
-import { fetchAgentRuns, formatRunStatus, formatRunTimestamp, isRunActive, isSubagentRun, runStatusColor, type AgentRun } from "../../lib/agentRuns";
+import { fetchAgentRuns, formatRunStatus, formatRunTimestamp, getRunStatusReason, isRunActive, isSubagentRun, runStatusColor, type AgentRun } from "../../lib/agentRuns";
 import { fetchThreadTodos } from "../../lib/agentTodos";
 import { buildHydratedRemoteMessage, type RemoteAgentMessageRecord, useAgentStore } from "../../lib/agentStore";
 import type { Workspace } from "../../lib/types";
@@ -337,12 +337,13 @@ export function SubagentsView({ onOpenThreadView, onOpenTasksView }: SubagentsVi
                             <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
                                 {group.items.map((run) => {
                                     const location = findTaskWorkspaceLocation(workspaces, run.session_id);
+                                    const statusReason = getRunStatusReason(run);
                                     return (
                                         <div
                                             key={run.id}
                                             style={{
                                                 borderRadius: "var(--radius-md)",
-                                                border: `1px solid ${runStatusColor(run.status)}`,
+                                                border: `1px solid ${runStatusColor(run)}`,
                                                 background: "var(--bg-tertiary)",
                                                 padding: "var(--space-3)",
                                             }}
@@ -357,6 +358,22 @@ export function SubagentsView({ onOpenThreadView, onOpenTasksView }: SubagentsVi
                                                     <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: "var(--space-2)" }}>
                                                         {run.description}
                                                     </div>
+                                                    {statusReason && (
+                                                        <div
+                                                            style={{
+                                                                fontSize: "var(--text-xs)",
+                                                                color: "var(--text-secondary)",
+                                                                marginTop: "var(--space-2)",
+                                                                padding: "6px 8px",
+                                                                borderRadius: "var(--radius-sm)",
+                                                                border: "1px solid var(--border)",
+                                                                background: "color-mix(in srgb, var(--bg-primary) 72%, transparent)",
+                                                                wordBreak: "break-word",
+                                                            }}
+                                                        >
+                                                            {statusReason}
+                                                        </div>
+                                                    )}
                                                     <div style={{ fontSize: "var(--text-xs)", color: "var(--text-secondary)", marginTop: "var(--space-2)" }}>
                                                         {run.thread_id ? `thread ${run.thread_id}` : "no chat thread yet"}
                                                         {run.session_id ? ` · session ${run.session_id}` : ""}

--- a/frontend/src/components/agent-chat-panel/runtime/useAgentChatPanelProviderValue.test.ts
+++ b/frontend/src/components/agent-chat-panel/runtime/useAgentChatPanelProviderValue.test.ts
@@ -18,6 +18,9 @@ function makeRun(overrides: Partial<AgentRun> = {}): AgentRun {
     title: "Root Agent",
     description: "Inspect the spawned agent",
     status: "in_progress",
+    runtime_status: {
+      kind: "running",
+    },
     priority: "normal",
     progress: 50,
     created_at: 1,

--- a/frontend/src/components/agent-chat-panel/tasks-view/TaskSection.test.tsx
+++ b/frontend/src/components/agent-chat-panel/tasks-view/TaskSection.test.tsx
@@ -14,6 +14,9 @@ function makeRun(overrides: Partial<AgentRun> = {}): AgentRun {
     title: "Root Agent",
     description: "Inspect the spawned agent",
     status: "in_progress",
+    runtime_status: {
+      kind: "running",
+    },
     priority: "normal",
     progress: 50,
     created_at: 1,

--- a/frontend/src/components/agent-chat-panel/tasks-view/TaskSection.tsx
+++ b/frontend/src/components/agent-chat-panel/tasks-view/TaskSection.tsx
@@ -1,3 +1,4 @@
+import { StatusChip } from "@/components/StatusChip";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { getBridge } from "@/lib/bridge";
 import { ActionButton, EmptyPanel, iconButtonStyle } from "../shared";
@@ -10,6 +11,9 @@ import {
 import {
   formatTaskStatus,
   formatTaskTimestamp,
+  getTaskStatusChip,
+  getTaskStatusReason,
+  getTaskStatusReasonChip,
   isTaskActive,
   isTaskTerminal,
   taskStatusColor,
@@ -137,6 +141,9 @@ export function TaskCard({
   onCancel?: () => void;
 }) {
   const statusColor = taskStatusColor(task.status);
+  const statusChip = getTaskStatusChip(task);
+  const statusReason = getTaskStatusReason(task);
+  const reasonChip = getTaskStatusReasonChip(task);
   const isActive = isTaskActive(task);
 
   return (
@@ -176,12 +183,12 @@ export function TaskCard({
               Subagent · runtime {task.runtime ?? "daemon"}
             </div>
           )}
-          <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 2 }}>
-            <span style={{ color: statusColor, fontWeight: 600 }}>{formatTaskStatus(task)}</span>
-            {task.status === "in_progress" && task.progress > 0 && <span> {task.progress}%</span>}
-            <span style={{ marginLeft: "var(--space-2)" }}>{formatTaskTimestamp(task.created_at)}</span>
+          <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 2, display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+            <StatusChip icon={statusChip.icon} label={statusChip.label} tone={statusChip.tone} />
+            {task.status === "in_progress" && task.progress > 0 && <span>{task.progress}%</span>}
+            <span>{formatTaskTimestamp(task.created_at)}</span>
             {typeof task.retry_count === "number" && typeof task.max_retries === "number" && (
-              <span style={{ marginLeft: "var(--space-2)" }}>
+              <span>
                 retry {task.retry_count}/{task.max_retries === 0 ? "∞" : task.max_retries}
               </span>
             )}
@@ -193,9 +200,20 @@ export function TaskCard({
           </button>
         )}
       </div>
-      {(task.blocked_reason || task.error) && (
-        <div style={{ fontSize: "var(--text-xs)", color: "var(--danger)", marginTop: "var(--space-2)" }}>
-          {task.blocked_reason ?? task.error}
+      {statusReason && (
+        <div
+          style={{
+            fontSize: "var(--text-xs)",
+            color: "var(--text-secondary)",
+            marginTop: "var(--space-2)",
+            display: "flex",
+            alignItems: "flex-start",
+            gap: "var(--space-2)",
+            flexWrap: "wrap",
+          }}
+        >
+          {reasonChip ? <StatusChip icon={reasonChip.icon} label={reasonChip.label} tone={reasonChip.tone} style={{ fontSize: 10, padding: "1px 6px" }} /> : null}
+          <span>{statusReason}</span>
         </div>
       )}
       {task.command && (
@@ -498,6 +516,9 @@ export function TaskPostMortem({
   const setActiveSurface = useWorkspaceStore((state) => state.setActiveSurface);
   const setActivePaneId = useWorkspaceStore((state) => state.setActivePaneId);
   const focusCanvasPanel = useWorkspaceStore((state) => state.focusCanvasPanel);
+  const statusChip = getTaskStatusChip(task);
+  const statusReason = getTaskStatusReason(task);
+  const reasonChip = getTaskStatusReasonChip(task);
   const logs = [...(task.logs ?? [])].slice(-8).reverse();
   const location = useMemo(
     () => findTaskWorkspaceLocation(workspaces, task.session_id),
@@ -526,8 +547,9 @@ export function TaskPostMortem({
           {task.goal_step_title && task.goal_step_title !== task.title ? ` · Step: ${task.goal_step_title}` : ""}
         </div>
       )}
-      <div style={{ fontSize: "var(--text-xs)", color: taskStatusColor(task.status), marginTop: 4 }}>
-        {formatTaskStatus(task)}
+      <div style={{ fontSize: "var(--text-xs)", marginTop: 4, display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+        <StatusChip icon={statusChip.icon} label={statusChip.label} tone={statusChip.tone} />
+        <span style={{ color: "var(--text-muted)" }}>{formatTaskStatus(task)}</span>
       </div>
       {task.command && (
         <div style={{ fontSize: "var(--text-xs)", color: "var(--text-secondary)", marginTop: "var(--space-2)" }}>
@@ -572,7 +594,13 @@ export function TaskPostMortem({
           <ActionButton onClick={() => onSelectTask(task.parent_task_id!)}>Back To Parent</ActionButton>
         </div>
       )}
-      {task.last_error && (
+      {statusReason && (
+        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-secondary)", marginTop: "var(--space-2)", display: "flex", alignItems: "flex-start", gap: "var(--space-2)", flexWrap: "wrap" }}>
+          {reasonChip ? <StatusChip icon={reasonChip.icon} label={reasonChip.label} tone={reasonChip.tone} style={{ fontSize: 10, padding: "1px 6px" }} /> : null}
+          <span>{statusReason}</span>
+        </div>
+      )}
+      {task.last_error && task.last_error !== statusReason && (
         <div style={{ fontSize: "var(--text-xs)", color: "var(--danger)", marginTop: "var(--space-2)" }}>
           {task.last_error}
         </div>

--- a/frontend/src/components/settings-panel/AgentTab.spec.ts
+++ b/frontend/src/components/settings-panel/AgentTab.spec.ts
@@ -1,4 +1,4 @@
-import { normalizeLlmStreamTimeoutInput } from "./AgentTab";
+import { getVisibleProviderOptions, normalizeLlmStreamTimeoutInput } from "./AgentTab";
 
 function assert(condition: unknown, message: string): void {
     if (!condition) {
@@ -19,4 +19,14 @@ assert(
 assert(
     normalizeLlmStreamTimeoutInput("29") === 30,
     "Timeout input should clamp to the minimum allowed value",
+);
+
+const visibleProviders = getVisibleProviderOptions([
+    { id: "opencode-go", label: "OpenCode Go" },
+    { id: "opencode-zen", label: "OpenCode Zen" },
+]);
+
+assert(
+    visibleProviders.some((provider) => provider.id === "opencode-go"),
+    "Visible provider options should include OpenCode Go",
 );

--- a/frontend/src/components/settings-panel/AgentTab.tsx
+++ b/frontend/src/components/settings-panel/AgentTab.tsx
@@ -27,6 +27,10 @@ export function normalizeLlmStreamTimeoutInput(value: string): number | null {
     return Math.min(1800, Math.max(30, parsed));
 }
 
+export function getVisibleProviderOptions(providerOptions: { id: AgentProviderId; label: string }[]) {
+    return providerOptions;
+}
+
 export function AgentTab({
     settings, updateSetting, resetSettings,
 }: {
@@ -76,16 +80,11 @@ export function AgentTab({
         { id: "minimax-coding-plan", label: "MiniMax Coding Plan" },
         { id: "alibaba-coding-plan", label: "Alibaba Coding Plan" },
         { id: "xiaomi-mimo-token-plan", label: "Xiaomi MiMo Token Plan" },
+        { id: "opencode-go", label: "OpenCode Go" },
         { id: "opencode-zen", label: "OpenCode Zen" },
         { id: "custom", label: "Custom" },
     ];
-    const providerOptions = allProviderOptions.filter((provider) =>
-        provider.id === "custom"
-        || provider.id === "azure-openai"
-        || providerAuthStates.some(
-            (state) => state.authenticated && state.provider_id === provider.id,
-        ),
-    );
+    const providerOptions = getVisibleProviderOptions(allProviderOptions);
 
     const providerConfig = settings[settings.active_provider] as AgentProviderConfig;
     const authCapability = getDaemonOwnedAuthCapability(settings.agent_backend);

--- a/frontend/src/lib/agentRuns.test.ts
+++ b/frontend/src/lib/agentRuns.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { formatRunStatus, getRunStatusReason, isRunActive, isRunTerminal, runStatusColor, type AgentRun } from "./agentRuns";
+
+function makeRun(overrides: Partial<AgentRun> = {}): AgentRun {
+  return {
+    id: "run-1",
+    task_id: "task-1",
+    kind: "subagent",
+    classification: "coding",
+    title: "Run",
+    description: "Inspect runtime status",
+    status: "blocked",
+    priority: "normal",
+    progress: 10,
+    created_at: 1,
+    source: "daemon",
+    ...overrides,
+  };
+}
+
+describe("agentRuns runtime_status wiring", () => {
+  it("formats normalized runtime statuses instead of coarse task status", () => {
+    const run = makeRun({
+      status: "blocked",
+      runtime_status: {
+        kind: "waiting_for_dependencies",
+        reason: "waiting for dependencies: task-a",
+      },
+    });
+
+    expect(formatRunStatus(run)).toBe("Waiting for dependencies");
+    expect(runStatusColor(run)).toBe("var(--text-muted)");
+    expect(isRunActive(run)).toBe(true);
+    expect(isRunTerminal(run)).toBe(false);
+  });
+
+  it("treats retrying as active warning state", () => {
+    const run = makeRun({
+      status: "failed_analyzing",
+      runtime_status: {
+        kind: "retrying",
+        next_retry_at: 123,
+      },
+    });
+
+    expect(formatRunStatus(run)).toBe("Retrying");
+    expect(runStatusColor(run)).toBe("var(--warning)");
+    expect(isRunActive(run)).toBe(true);
+  });
+
+  it("treats normalized terminal states as terminal", () => {
+    const run = makeRun({
+      status: "in_progress",
+      runtime_status: {
+        kind: "completed",
+      },
+    });
+
+    expect(formatRunStatus(run)).toBe("Completed");
+    expect(runStatusColor(run)).toBe("var(--success)");
+    expect(isRunTerminal(run)).toBe(true);
+    expect(isRunActive(run)).toBe(false);
+  });
+
+  it("falls back to coarse task status when runtime_status is absent", () => {
+    const run = makeRun({ status: "awaiting_approval", runtime_status: undefined });
+
+    expect(formatRunStatus(run)).toBe("Awaiting approval");
+    expect(runStatusColor(run)).toBe("var(--approval)");
+  });
+
+  it("surfaces runtime_status reason with blocked_reason fallback", () => {
+    const runtimeReasonRun = makeRun({
+      runtime_status: {
+        kind: "waiting_for_resources",
+        reason: "waiting for workspace lock: repo-main",
+      },
+      blocked_reason: "older blocked reason",
+    });
+    const fallbackRun = makeRun({
+      runtime_status: undefined,
+      blocked_reason: "waiting for dependencies: task-a",
+    });
+    const emptyRun = makeRun({
+      runtime_status: {
+        kind: "blocked",
+        reason: "   ",
+      },
+      blocked_reason: "   ",
+    });
+
+    expect(getRunStatusReason(runtimeReasonRun)).toBe("waiting for workspace lock: repo-main");
+    expect(getRunStatusReason(fallbackRun)).toBe("waiting for dependencies: task-a");
+    expect(getRunStatusReason(emptyRun)).toBeNull();
+  });
+});

--- a/frontend/src/lib/agentRuns.test.ts
+++ b/frontend/src/lib/agentRuns.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatRunStatus, getRunStatusReason, isRunActive, isRunTerminal, runStatusColor, type AgentRun } from "./agentRuns";
+import { formatRunStatus, getRunStatusChip, getRunStatusReason, getRunStatusReasonChip, isRunActive, isRunTerminal, runStatusColor, type AgentRun } from "./agentRuns";
 
 function makeRun(overrides: Partial<AgentRun> = {}): AgentRun {
   return {
@@ -89,8 +89,28 @@ describe("agentRuns runtime_status wiring", () => {
       blocked_reason: "   ",
     });
 
-    expect(getRunStatusReason(runtimeReasonRun)).toBe("waiting for workspace lock: repo-main");
-    expect(getRunStatusReason(fallbackRun)).toBe("waiting for dependencies: task-a");
+    expect(getRunStatusReason(runtimeReasonRun)).toBe("Workspace: repo-main");
+    expect(getRunStatusReason(fallbackRun)).toBe("Dependencies: task-a");
     expect(getRunStatusReason(emptyRun)).toBeNull();
+  });
+
+  it("returns specific status and reason chips for normalized runtime states", () => {
+    const dependencyRun = makeRun({
+      runtime_status: {
+        kind: "waiting_for_dependencies",
+        reason: "waiting for dependencies: task-a, task-b",
+      },
+    });
+    const approvalRun = makeRun({
+      runtime_status: {
+        kind: "awaiting_approval",
+        reason: "waiting for operator approval: review_command",
+      },
+    });
+
+    expect(getRunStatusChip(dependencyRun)).toEqual({ icon: "⇢", label: "Deps", tone: "neutral" });
+    expect(getRunStatusReasonChip(dependencyRun)).toEqual({ icon: "⇢", label: "Depends on" });
+    expect(getRunStatusChip(approvalRun)).toEqual({ icon: "⚑", label: "Approval", tone: "approval" });
+    expect(getRunStatusReasonChip(approvalRun)).toEqual({ icon: "⚑", label: "Approval" });
   });
 });

--- a/frontend/src/lib/agentRuns.ts
+++ b/frontend/src/lib/agentRuns.ts
@@ -3,6 +3,29 @@ import { formatTaskStatus, formatTaskTimestamp, isTaskActive, isTaskTerminal, ta
 
 export type AgentRunKind = "task" | "subagent";
 export type AgentRunClassification = "coding" | "research" | "ops" | "browser" | "messaging" | "mixed" | string;
+export type AgentRunRuntimeStatusKind =
+    | "queued"
+    | "running"
+    | "awaiting_approval"
+    | "waiting_for_dependencies"
+    | "waiting_for_subagents"
+    | "scheduled"
+    | "waiting_for_resources"
+    | "blocked"
+    | "retrying"
+    | "failed_analyzing"
+    | "budget_exceeded"
+    | "completed"
+    | "failed"
+    | "cancelled";
+
+export interface AgentRunRuntimeStatus {
+    kind: AgentRunRuntimeStatusKind;
+    reason?: string | null;
+    awaiting_approval_id?: string | null;
+    next_retry_at?: number | null;
+    scheduled_at?: number | null;
+}
 
 export interface AgentRun {
     id: string;
@@ -12,6 +35,7 @@ export interface AgentRun {
     title: string;
     description: string;
     status: AgentTaskStatus;
+    runtime_status?: AgentRunRuntimeStatus | null;
     priority: AgentTaskPriority;
     progress: number;
     created_at: number;
@@ -51,10 +75,18 @@ export async function fetchAgentRuns(): Promise<AgentRun[]> {
 }
 
 export function isRunTerminal(run: AgentRun): boolean {
+    const runtimeKind = run.runtime_status?.kind;
+    if (runtimeKind) {
+        return runtimeKind === "completed" || runtimeKind === "failed" || runtimeKind === "cancelled";
+    }
     return isTaskTerminal(run);
 }
 
 export function isRunActive(run: AgentRun): boolean {
+    const runtimeKind = run.runtime_status?.kind;
+    if (runtimeKind) {
+        return !(runtimeKind === "completed" || runtimeKind === "failed" || runtimeKind === "cancelled");
+    }
     return isTaskActive(run);
 }
 
@@ -63,11 +95,76 @@ export function isSubagentRun(run: AgentRun): boolean {
 }
 
 export function formatRunStatus(run: AgentRun): string {
-    return formatTaskStatus(run);
+    switch (run.runtime_status?.kind) {
+        case "running":
+            return "Running";
+        case "awaiting_approval":
+            return "Awaiting approval";
+        case "waiting_for_dependencies":
+            return "Waiting for dependencies";
+        case "waiting_for_subagents":
+            return "Waiting for subagents";
+        case "scheduled":
+            return "Scheduled";
+        case "waiting_for_resources":
+            return "Waiting for resources";
+        case "retrying":
+            return "Retrying";
+        case "failed_analyzing":
+            return "Analyzing failure";
+        case "budget_exceeded":
+            return "Budget exceeded";
+        case "completed":
+            return "Completed";
+        case "failed":
+            return "Failed";
+        case "cancelled":
+            return "Cancelled";
+        case "queued":
+            return "Queued";
+        case "blocked":
+            return "Blocked";
+        default:
+            return formatTaskStatus(run);
+    }
 }
 
-export function runStatusColor(status: AgentTaskStatus): string {
-    return taskStatusColor(status);
+export function runStatusColor(run: AgentRun): string {
+    switch (run.runtime_status?.kind) {
+        case "running":
+            return "var(--accent)";
+        case "awaiting_approval":
+            return "var(--approval)";
+        case "waiting_for_dependencies":
+        case "waiting_for_subagents":
+        case "scheduled":
+        case "waiting_for_resources":
+        case "blocked":
+            return "var(--text-muted)";
+        case "retrying":
+        case "failed_analyzing":
+        case "budget_exceeded":
+            return "var(--warning)";
+        case "completed":
+            return "var(--success)";
+        case "failed":
+            return "var(--danger)";
+        case "cancelled":
+            return "var(--text-muted)";
+        case "queued":
+            return "var(--text-secondary)";
+        default:
+            return taskStatusColor(run.status);
+    }
+}
+
+export function getRunStatusReason(run: AgentRun): string | null {
+    const reason = run.runtime_status?.reason ?? run.blocked_reason ?? null;
+    if (typeof reason !== "string") {
+        return null;
+    }
+    const trimmed = reason.trim();
+    return trimmed.length > 0 ? trimmed : null;
 }
 
 export function formatRunTimestamp(timestamp?: number | null): string {

--- a/frontend/src/lib/agentRuns.ts
+++ b/frontend/src/lib/agentRuns.ts
@@ -1,5 +1,20 @@
 import { getBridge } from "./bridge";
 import { formatTaskStatus, formatTaskTimestamp, isTaskActive, isTaskTerminal, taskStatusColor, type AgentTaskPriority, type AgentTaskStatus } from "./agentTaskQueue";
+import type { StatusChipTone } from "./statusChips";
+
+export type RunStatusTone = StatusChipTone;
+
+export type RunStatusChip = {
+    icon: string;
+    label: string;
+    tone: RunStatusTone;
+};
+
+export type RunStatusReasonChip = {
+    icon: string;
+    label: string;
+    tone: RunStatusTone;
+};
 
 export type AgentRunKind = "task" | "subagent";
 export type AgentRunClassification = "coding" | "research" | "ops" | "browser" | "messaging" | "mixed" | string;
@@ -129,6 +144,45 @@ export function formatRunStatus(run: AgentRun): string {
     }
 }
 
+export function getRunStatusChip(run: AgentRun): RunStatusChip {
+    switch (run.runtime_status?.kind) {
+        case "running":
+            return { icon: "●", label: "Running", tone: "accent" };
+        case "awaiting_approval":
+            return { icon: "⚑", label: "Approval", tone: "approval" };
+        case "waiting_for_dependencies":
+            return { icon: "⇢", label: "Deps", tone: "neutral" };
+        case "waiting_for_subagents":
+            return { icon: "◌", label: "Children", tone: "neutral" };
+        case "scheduled":
+            return { icon: "◷", label: "Scheduled", tone: "neutral" };
+        case "waiting_for_resources":
+            return { icon: "⌛", label: "Resources", tone: "neutral" };
+        case "retrying":
+            return { icon: "↻", label: "Retrying", tone: "warning" };
+        case "failed_analyzing":
+            return { icon: "△", label: "Analyzing", tone: "warning" };
+        case "budget_exceeded":
+            return { icon: "⚠", label: "Budget", tone: "warning" };
+        case "completed":
+            return { icon: "✓", label: "Done", tone: "success" };
+        case "failed":
+            return { icon: "✕", label: "Failed", tone: "danger" };
+        case "cancelled":
+            return { icon: "—", label: "Cancelled", tone: "neutral" };
+        case "queued":
+            return { icon: "○", label: "Queued", tone: "neutral" };
+        case "blocked":
+            return { icon: "⏸", label: "Blocked", tone: "neutral" };
+        default:
+            return {
+                icon: "○",
+                label: formatRunStatus(run),
+                tone: "neutral",
+            };
+    }
+}
+
 export function runStatusColor(run: AgentRun): string {
     switch (run.runtime_status?.kind) {
         case "running":
@@ -164,7 +218,57 @@ export function getRunStatusReason(run: AgentRun): string | null {
         return null;
     }
     const trimmed = reason.trim();
-    return trimmed.length > 0 ? trimmed : null;
+    if (trimmed.length === 0) {
+        return null;
+    }
+
+    return shortenRunStatusReason(trimmed);
+}
+
+export function getRunStatusReasonChip(run: AgentRun): RunStatusReasonChip | null {
+    switch (run.runtime_status?.kind) {
+        case "awaiting_approval":
+            return { icon: "⚑", label: "Approval", tone: "approval" };
+        case "waiting_for_dependencies":
+            return { icon: "⇢", label: "Depends on", tone: "neutral" };
+        case "waiting_for_subagents":
+            return { icon: "◌", label: "Waiting on", tone: "neutral" };
+        case "scheduled":
+            return { icon: "◷", label: "At", tone: "neutral" };
+        case "waiting_for_resources":
+            return { icon: "⌛", label: "Resource", tone: "neutral" };
+        case "retrying":
+            return { icon: "↻", label: "Retry", tone: "warning" };
+        case "failed_analyzing":
+            return { icon: "△", label: "Analysis", tone: "warning" };
+        case "budget_exceeded":
+            return { icon: "⚠", label: "Budget", tone: "warning" };
+        case "blocked":
+            return { icon: "⏸", label: "Blocked", tone: "neutral" };
+        default:
+            return null;
+    }
+}
+
+function shortenRunStatusReason(reason: string): string {
+    const prefixes: Array<[string, string]> = [
+        ["waiting for dependencies:", "Dependencies: "],
+        ["waiting for subagents:", "Subagents: "],
+        ["waiting for workspace lock:", "Workspace: "],
+        ["waiting for lane availability:", "Lane: "],
+        ["waiting for subagent slot:", "Slot: "],
+        ["waiting for operator approval:", "Approval: "],
+        ["scheduled for ", "At "],
+    ];
+
+    const lower = reason.toLowerCase();
+    for (const [prefix, replacement] of prefixes) {
+        if (lower.startsWith(prefix)) {
+            return `${replacement}${reason.slice(prefix.length).trim()}`;
+        }
+    }
+
+    return reason;
 }
 
 export function formatRunTimestamp(timestamp?: number | null): string {

--- a/frontend/src/lib/agentStore/providers.ts
+++ b/frontend/src/lib/agentStore/providers.ts
@@ -158,6 +158,18 @@ const OPENCODE_ZEN_MODELS: ModelDefinition[] = [
   { id: "kimi-k2.5", name: "Kimi K2.5", contextWindow: 262144 },
 ];
 
+const OPENCODE_GO_MODELS: ModelDefinition[] = [
+  { id: "glm-5.1", name: "GLM-5.1", contextWindow: 204800 },
+  { id: "glm-5", name: "GLM-5", contextWindow: 202752 },
+  { id: "kimi-k2.5", name: "Kimi K2.5", contextWindow: 262144 },
+  { id: "mimo-v2-pro", name: "MiMo V2 Pro", contextWindow: 1_000_000 },
+  { id: "mimo-v2-omni", name: "MiMo V2 Omni", contextWindow: 256_000, modalities: M_MULTI },
+  { id: "minimax-m2.5", name: "MiniMax M2.5", contextWindow: 205000 },
+  { id: "minimax-m2.7", name: "MiniMax M2.7", contextWindow: 205000 },
+  { id: "qwen3.5-plus", name: "Qwen3.5 Plus", contextWindow: 983616 },
+  { id: "qwen3.6-plus", name: "Qwen3.6 Plus", contextWindow: 983616 },
+];
+
 const GROQ_MODELS: ModelDefinition[] = [
   { id: "llama-3.3-70b-versatile", name: "Llama 3.3 70B Versatile", contextWindow: 128000 },
   { id: "llama-3.1-8b-instant", name: "Llama 3.1 8B", contextWindow: 128000 },
@@ -287,6 +299,7 @@ export const PROVIDER_DEFINITIONS: ProviderDefinition[] = [
   { id: "minimax-coding-plan", name: "MiniMax Coding Plan", defaultBaseUrl: "https://api.minimax.io/anthropic", defaultModel: "MiniMax-M2.7", apiType: "anthropic", authMethod: "x-api-key", models: MINIMAX_MODELS, supportsModelFetch: false, supportedTransports: CHAT_ONLY_TRANSPORTS, defaultTransport: "chat_completions", supportedAuthSources: API_KEY_ONLY_AUTH_SOURCES, defaultAuthSource: "api_key", supportsResponseContinuity: false },
   { id: "alibaba-coding-plan", name: "Alibaba Coding Plan", defaultBaseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1", defaultModel: "qwen3.6-plus", apiType: "openai", authMethod: "bearer", models: ALIBABA_CODING_MODELS, supportsModelFetch: false, supportedTransports: CHAT_ONLY_TRANSPORTS, defaultTransport: "chat_completions", supportedAuthSources: API_KEY_ONLY_AUTH_SOURCES, defaultAuthSource: "api_key", supportsResponseContinuity: false },
   { id: "xiaomi-mimo-token-plan", name: "Xiaomi MiMo Token Plan", defaultBaseUrl: "https://api.xiaomimimo.com/v1", defaultModel: "mimo-v2-pro", apiType: "openai", authMethod: "bearer", models: XIAOMI_MIMO_TOKEN_PLAN_MODELS, supportsModelFetch: false, supportedTransports: CHAT_ONLY_TRANSPORTS, defaultTransport: "chat_completions", supportedAuthSources: API_KEY_ONLY_AUTH_SOURCES, defaultAuthSource: "api_key", supportsResponseContinuity: false },
+  { id: "opencode-go", name: "OpenCode Go", defaultBaseUrl: "https://opencode.ai/zen/go/v1", defaultModel: "glm-5.1", apiType: "openai", authMethod: "bearer", models: OPENCODE_GO_MODELS, supportsModelFetch: true, supportedTransports: CHAT_ONLY_TRANSPORTS, defaultTransport: "chat_completions", supportedAuthSources: API_KEY_ONLY_AUTH_SOURCES, defaultAuthSource: "api_key", supportsResponseContinuity: false },
   { id: "opencode-zen", name: "OpenCode Zen", defaultBaseUrl: "https://opencode.ai/zen/v1", defaultModel: "claude-sonnet-4-5", apiType: "anthropic", authMethod: "bearer", models: OPENCODE_ZEN_MODELS, supportsModelFetch: true, supportedTransports: CHAT_ONLY_TRANSPORTS, defaultTransport: "chat_completions", supportedAuthSources: API_KEY_ONLY_AUTH_SOURCES, defaultAuthSource: "api_key", supportsResponseContinuity: false },
   { id: "custom", name: "Custom", defaultBaseUrl: "", defaultModel: "", apiType: "openai", authMethod: "bearer", models: EMPTY_MODELS, supportsModelFetch: false, supportedTransports: RESPONSES_AND_CHAT_TRANSPORTS, defaultTransport: "responses", supportedAuthSources: API_KEY_ONLY_AUTH_SOURCES, defaultAuthSource: "api_key", supportsResponseContinuity: true },
 ];
@@ -430,6 +443,14 @@ function isAlibabaCodingPlanAnthropicBaseUrl(baseUrl: string): boolean {
   return lower.includes("dashscope.aliyuncs.com") && lower.includes("/apps/anthropic");
 }
 
+function opencodeGoUsesAnthropicApi(model: string): boolean {
+  const normalized = (model || "").trim().toLowerCase();
+  const unprefixed = normalized.startsWith("opencode-go/")
+    ? normalized.slice("opencode-go/".length)
+    : normalized;
+  return unprefixed.startsWith("minimax-m2.");
+}
+
 export function getProviderApiType(
   providerId: AgentProviderId,
   model: string,
@@ -443,6 +464,9 @@ export function getProviderApiType(
     return "anthropic";
   }
   if (definition.anthropicBaseUrl && model.startsWith("claude")) {
+    return "anthropic";
+  }
+  if (providerId === "opencode-go" && opencodeGoUsesAnthropicApi(model)) {
     return "anthropic";
   }
   if (providerId === "opencode-zen" && !model.startsWith("claude")) {

--- a/frontend/src/lib/agentStore/settings.ts
+++ b/frontend/src/lib/agentStore/settings.ts
@@ -84,6 +84,7 @@ export interface AgentSettings {
   "minimax-coding-plan": AgentProviderConfig;
   "alibaba-coding-plan": AgentProviderConfig;
   "xiaomi-mimo-token-plan": AgentProviderConfig;
+  "opencode-go": AgentProviderConfig;
   "opencode-zen": AgentProviderConfig;
   custom: AgentProviderConfig;
   enable_bash_tool: boolean;
@@ -187,6 +188,7 @@ export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
   "minimax-coding-plan": { base_url: "https://api.minimax.io/anthropic", model: "MiniMax-M2.7", custom_model_name: "", api_key: "", assistant_id: "", api_transport: "chat_completions", auth_source: "api_key", context_window_tokens: null },
   "alibaba-coding-plan": { base_url: "https://coding-intl.dashscope.aliyuncs.com/v1", model: "qwen3.6-plus", custom_model_name: "", api_key: "", assistant_id: "", api_transport: "chat_completions", auth_source: "api_key", context_window_tokens: null },
   "xiaomi-mimo-token-plan": { base_url: "https://api.xiaomimimo.com/v1", model: "mimo-v2-pro", custom_model_name: "", api_key: "", assistant_id: "", api_transport: "chat_completions", auth_source: "api_key", context_window_tokens: null },
+  "opencode-go": { base_url: "https://opencode.ai/zen/go/v1", model: "glm-5.1", custom_model_name: "", api_key: "", assistant_id: "", api_transport: "chat_completions", auth_source: "api_key", context_window_tokens: null },
   "opencode-zen": { base_url: "https://opencode.ai/zen/v1", model: "claude-sonnet-4-5", custom_model_name: "", api_key: "", assistant_id: "", api_transport: "chat_completions", auth_source: "api_key", context_window_tokens: null },
   custom: { base_url: "", model: "", custom_model_name: "", api_key: "", assistant_id: "", api_transport: "responses", auth_source: "api_key", context_window_tokens: 128_000 },
   enable_bash_tool: true,
@@ -452,6 +454,7 @@ export function normalizeAgentSettingsFromSource(source: DiskAgentSettings): Age
     "minimax-coding-plan": providerConfigFromRaw("minimax-coding-plan", source),
     "alibaba-coding-plan": providerConfigFromRaw("alibaba-coding-plan", source),
     "xiaomi-mimo-token-plan": providerConfigFromRaw("xiaomi-mimo-token-plan", source),
+    "opencode-go": providerConfigFromRaw("opencode-go", source),
     "opencode-zen": providerConfigFromRaw("opencode-zen", source),
     custom: providerConfigFromRaw("custom", source),
     system_prompt: source.system_prompt ?? DEFAULT_AGENT_SETTINGS.system_prompt,

--- a/frontend/src/lib/agentStore/types.ts
+++ b/frontend/src/lib/agentStore/types.ts
@@ -77,6 +77,7 @@ export type AgentProviderId =
   | "minimax-coding-plan"
   | "alibaba-coding-plan"
   | "xiaomi-mimo-token-plan"
+  | "opencode-go"
   | "opencode-zen"
   | "custom";
 
@@ -106,6 +107,7 @@ export const AGENT_PROVIDER_IDS: AgentProviderId[] = [
   "minimax-coding-plan",
   "alibaba-coding-plan",
   "xiaomi-mimo-token-plan",
+  "opencode-go",
   "opencode-zen",
   "custom",
 ];

--- a/frontend/src/lib/agentTaskQueue.ts
+++ b/frontend/src/lib/agentTaskQueue.ts
@@ -1,4 +1,5 @@
 import { getBridge } from "./bridge";
+import type { StatusChipTone } from "./statusChips";
 
 export type AgentTaskStatus =
     | "queued"
@@ -12,6 +13,20 @@ export type AgentTaskStatus =
     | "cancelled";
 
 export type AgentTaskPriority = "low" | "normal" | "high" | "urgent";
+
+export type TaskStatusTone = StatusChipTone;
+
+export type TaskStatusChip = {
+    icon: string;
+    label: string;
+    tone: TaskStatusTone;
+};
+
+export type TaskStatusReasonChip = {
+    icon: string;
+    label: string;
+    tone: TaskStatusTone;
+};
 
 export type AgentTaskLogLevel = "info" | "warn" | "error";
 
@@ -123,6 +138,87 @@ export function taskStatusColor(status: AgentTaskStatus): string {
         default:
             return "var(--text-secondary)";
     }
+}
+
+export function getTaskStatusChip(task: AgentQueueTask): TaskStatusChip {
+    switch (task.status) {
+        case "in_progress":
+            return { icon: "●", label: "Running", tone: "accent" };
+        case "awaiting_approval":
+            return { icon: "⚑", label: "Approval", tone: "approval" };
+        case "blocked":
+            return { icon: "⏸", label: "Blocked", tone: "neutral" };
+        case "failed_analyzing":
+            return { icon: "△", label: "Analyzing", tone: "warning" };
+        case "budget_exceeded":
+            return { icon: "⚠", label: "Budget", tone: "warning" };
+        case "completed":
+            return { icon: "✓", label: "Done", tone: "success" };
+        case "failed":
+            return { icon: "✕", label: "Failed", tone: "danger" };
+        case "cancelled":
+            return { icon: "—", label: "Cancelled", tone: "neutral" };
+        case "queued":
+        default:
+            return { icon: "○", label: "Queued", tone: "neutral" };
+    }
+}
+
+export function getTaskStatusReason(task: AgentQueueTask): string | null {
+    const reason = task.blocked_reason ?? task.error ?? null;
+    if (typeof reason !== "string") {
+        return null;
+    }
+
+    const trimmed = reason.trim();
+    if (trimmed.length === 0) {
+        return null;
+    }
+
+    return shortenTaskStatusReason(trimmed);
+}
+
+export function getTaskStatusReasonChip(task: AgentQueueTask): TaskStatusReasonChip | null {
+    if (!getTaskStatusReason(task)) {
+        return null;
+    }
+
+    switch (task.status) {
+        case "awaiting_approval":
+            return { icon: "⚑", label: "Approval", tone: "approval" };
+        case "blocked":
+            return { icon: "⏸", label: "Blocked", tone: "neutral" };
+        case "failed_analyzing":
+            return { icon: "△", label: "Analysis", tone: "warning" };
+        case "budget_exceeded":
+            return { icon: "⚠", label: "Budget", tone: "warning" };
+        case "failed":
+            return { icon: "✕", label: "Error", tone: "danger" };
+        default:
+            return task.blocked_reason
+                ? { icon: "⏸", label: "Gate", tone: "neutral" }
+                : { icon: "✕", label: "Error", tone: "danger" };
+    }
+}
+
+function shortenTaskStatusReason(reason: string): string {
+    const prefixes: Array<[string, string]> = [
+        ["waiting for dependencies:", "Dependencies: "],
+        ["waiting for subagents:", "Subagents: "],
+        ["waiting for workspace lock:", "Workspace: "],
+        ["waiting for lane availability:", "Lane: "],
+        ["waiting for operator approval:", "Approval: "],
+        ["scheduled for ", "At "],
+    ];
+
+    const lower = reason.toLowerCase();
+    for (const [prefix, replacement] of prefixes) {
+        if (lower.startsWith(prefix)) {
+            return `${replacement}${reason.slice(prefix.length).trim()}`;
+        }
+    }
+
+    return reason;
 }
 
 export function formatTaskTimestamp(timestamp?: number | null): string {

--- a/frontend/src/lib/agentTaskQueue.ts
+++ b/frontend/src/lib/agentTaskQueue.ts
@@ -6,6 +6,7 @@ export type AgentTaskStatus =
     | "awaiting_approval"
     | "blocked"
     | "failed_analyzing"
+    | "budget_exceeded"
     | "completed"
     | "failed"
     | "cancelled";
@@ -94,6 +95,8 @@ export function formatTaskStatus(task: AgentQueueTask): string {
             return "Awaiting approval";
         case "failed_analyzing":
             return "Analyzing failure";
+        case "budget_exceeded":
+            return "Budget exceeded";
         default:
             return task.status.replace(/_/g, " ");
     }
@@ -108,6 +111,8 @@ export function taskStatusColor(status: AgentTaskStatus): string {
         case "blocked":
             return "var(--text-muted)";
         case "failed_analyzing":
+            return "var(--warning)";
+        case "budget_exceeded":
             return "var(--warning)";
         case "completed":
             return "var(--success)";

--- a/frontend/src/lib/statusChips.ts
+++ b/frontend/src/lib/statusChips.ts
@@ -1,0 +1,1 @@
+export type StatusChipTone = "neutral" | "accent" | "approval" | "warning" | "success" | "danger";

--- a/frontend/src/types/amux-bridge.d.ts
+++ b/frontend/src/types/amux-bridge.d.ts
@@ -191,9 +191,34 @@ declare global {
         | "awaiting_approval"
         | "blocked"
         | "failed_analyzing"
+        | "budget_exceeded"
         | "completed"
         | "failed"
         | "cancelled";
+
+    type AmuxAgentRunRuntimeStatusKind =
+        | "queued"
+        | "running"
+        | "awaiting_approval"
+        | "waiting_for_dependencies"
+        | "waiting_for_subagents"
+        | "scheduled"
+        | "waiting_for_resources"
+        | "blocked"
+        | "retrying"
+        | "failed_analyzing"
+        | "budget_exceeded"
+        | "completed"
+        | "failed"
+        | "cancelled";
+
+    type AmuxAgentRunRuntimeStatus = {
+        kind: AmuxAgentRunRuntimeStatusKind;
+        reason?: string | null;
+        awaiting_approval_id?: string | null;
+        next_retry_at?: number | null;
+        scheduled_at?: number | null;
+    };
 
     type AmuxAgentRunPriority = "low" | "normal" | "high" | "urgent";
 
@@ -205,6 +230,7 @@ declare global {
         title: string;
         description: string;
         status: AmuxAgentRunStatus;
+        runtime_status?: AmuxAgentRunRuntimeStatus | null;
         priority: AmuxAgentRunPriority;
         progress: number;
         created_at: number;


### PR DESCRIPTION
## Summary

Establishes a baseline of observed Decisions for `Argument` fixtures mimicking LLM output (uniform-weight points, arbitrary evidence strings, mixed confidences). No arbiter behavior changes.

- Adds `crates/amux-daemon/src/agent/critique/tests/arbiter_calibration.rs` (16 active tests + 1 `#[ignore]`)
- Wires the module via `#[cfg(test)] mod tests { pub(crate) mod arbiter_calibration; }` in `critique/mod.rs`
- Covers all four `Decision` variants, all three `RiskTolerance` levels, both satisfaction labels (`strained`, `fragile`), duplicate-claim dedup, and a >220-char evidence string no-panic check

Useful for catching drift when LLM-driven `run_plan_critique` lands.

## Observed Decisions (baseline)

| # | Fixture | Risk | Label | Expected | Observed | Status |
|---|---------|------|-------|----------|----------|--------|
| 1 | Strong advocate (0.9), weak critic (0.2) | Moderate | — | Proceed | Proceed | PASS |
| 2 | Strong advocate (0.85), blocking critic (0.50) | Moderate | — | ProceedWithModifications | ProceedWithModifications | PASS |
| 3 | Weak advocate (0.20), strong critic (0.80) | Conservative | — | Defer or Reject | Reject | PASS |
| 4 | Strong advocate (0.80), strong critic (0.50) | Aggressive | — | Proceed or PWM | Proceed | PASS |
| 5 | Empty critic | Moderate | — | Proceed | Proceed | PASS |
| 6 | Empty advocate, populated critic (0.90) | Conservative | — | Defer or Reject | Reject | PASS |
| 7 | High-conf advocate (0.95, 0.85pts), medium critic (0.40) | Moderate | — | Proceed or PWM | Proceed | PASS |
| 8 | Low-conf both (0.35 vs 0.30) | Moderate | — | Defer | Defer | PASS |
| 9 | Duplicate claims (0.40×2 vs 0.40×2) | Moderate | — | Defer (deterministic) | Defer | PASS |
| 10 | Uniform LLM weights (1.0 vs 1.0) | Moderate | — | document only | Defer (tie) | IGNORED (calibration gap) |
| 11a | strained × Conservative | Conservative | strained | not Reject | ProceedWithModifications | PASS |
| 11b | strained × Balanced (Defer→PWM) | Moderate | strained | PWM or Proceed | ProceedWithModifications | PASS |
| 11c | strained × Aggressive | Aggressive | strained | Proceed or PWM | ProceedWithModifications | PASS |
| 12a | fragile × Conservative | Conservative | fragile | not bare Proceed | ProceedWithModifications | PASS |
| 12b | fragile × Balanced (Defer→PWM) | Moderate | fragile | PWM or Proceed | ProceedWithModifications | PASS |
| 12c | fragile × Aggressive | Aggressive | fragile | Proceed or PWM | Proceed | PASS |
| — | Long evidence (>220 chars) no-panic | Moderate | — | no panic | no panic | PASS |

## Test plan
- [x] `cargo test -p tamux-daemon arbiter_calibration` — 16 passed, 1 ignored
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)